### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/aidasofialily-cmd/code/security/code-scanning/1](https://github.com/aidasofialily-cmd/code/security/code-scanning/1)

To fix the problem, explicitly declare a `permissions` block that grants the least privilege required. This workflow only checks out code and runs local Rust build/test commands, so it only needs read access to repository contents; no write permissions or other scopes (issues, pull-requests, etc.) are necessary.

The best fix without changing existing functionality is to add a top-level `permissions` block right after the `name` (or before `on:`) in `.github/workflows/rust.yml`:

- Add:
  ```yaml
  permissions:
    contents: read
  ```
  at the root of the workflow. This will apply to all jobs (`build` is the only one) that do not override `permissions`.
- No other steps, jobs, or actions need modification.
- No imports or external libraries are needed; this is a pure YAML configuration change within the existing file.

Concretely: edit `.github/workflows/rust.yml` around lines 1–4 to insert the new `permissions` block between `name: Rust` and `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
