### PR TITLE
🎨 Palette: Improve game start UX and fix broken macros

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-02-13 - Tactile Feedback in CLI
 **Learning:** In terminal-based games, users expect immediate visual feedback for their actions. Relying on a periodic "tick" to update the UI creates a laggy feel. Using `poll()` with a dynamic timeout allows the application to remain idle yet wake up instantly to process and render user input.
 **Action:** Always trigger a UI refresh immediately after processing user input in CLI applications, and use efficient waiting mechanisms (like `poll`) that can be interrupted by input.
+
+## 2026-02-15 - Pre-Game Countdown for CLI
+**Learning:** Incorporating an animated countdown (e.g., 3-2-1-GO) before starting time-sensitive CLI games improves UX by signaling the transition from menu to active gameplay and allowing user preparation. Coupled with `tcflush`, it ensures a fair and responsive start.
+**Action:** Use countdowns and input buffer flushes for real-time terminal interactions that require user focus.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,19 @@
 #include <termios.h>
 #include <algorithm>
 
+#define CLR_RESET "\033[0m"
+#define CLR_SCORE "\033[1;32m"
+#define CLR_HARD  "\033[1;31m"
+#define CLR_NORM  "\033[1;34m"
+#define CLR_CTRL  "\033[1;33m"
+
+// Aliases for the messier parts of the code
+#define RESET     CLR_RESET
+#define GREEN     CLR_SCORE
+#define RED       CLR_HARD
+#define BLUE      CLR_NORM
+#define YELLOW    CLR_CTRL
+
 int main() {
     struct termios oldt, newt;
     tcgetattr(STDIN_FILENO, &oldt);
@@ -14,12 +27,18 @@ int main() {
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     int score = 0; bool hardMode = false; char input;
-    std::cout << YELLOW << "==========================\n      SPEED CLICKER\n==========================\n" << RESET
-              << "Controls:\n " << YELLOW << "[h]" << RESET << " Toggle Hard Mode (10x Speed!)\n "
-              << YELLOW << "[q]" << RESET << " Quit Game\n " << YELLOW << "[Any key]" << RESET << " Click!\n\n";
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET
               << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
-              << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n [Any key] Click!\n\n";
+              << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
+
+    std::cout << "Starting in..." << std::endl;
+    for (int i = 3; i > 0; --i) {
+        std::cout << CLR_CTRL << i << "..." << CLR_RESET << std::flush;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::cout << "\r            \r";
+    }
+    std::cout << CLR_SCORE << "GO!" << CLR_RESET << std::endl;
+    tcflush(STDIN_FILENO, TCIFLUSH);
 
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     auto last_tick = std::chrono::steady_clock::now();
@@ -46,12 +65,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << GREEN << "Score: " << score << RESET
-                      << (hardMode ? RED " [FAST]    " : BLUE " [NORMAL]  ") << RESET
-                      << "      \r" << std::flush;
             std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << "    " << std::flush;
+                      << "          " << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Added a 3-second countdown before the game starts, implemented `tcflush` to clear accidental input during the countdown, and fixed the broken build by defining missing ANSI color macros and removing redundant output blocks.
🎯 Why: The game lacked a preparation phase, making the start feel abrupt. Also, the source code was broken due to missing macro definitions and duplicate code blocks, preventing compilation.
📸 Before/After:
Before: Game fails to compile. Redundant code in header and loop.
After: Game compiles and starts with a professional "3... 2... 1... GO!" countdown.
♿ Accessibility: Clearer visual signaling of the game start state.

---
*PR created automatically by Jules for task [7460835642192337347](https://jules.google.com/task/7460835642192337347) started by @aidasofialily-cmd*