### PR TITLE
🎨 Palette: [UX improvement] Add pre-game countdown and fix UI colors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-02-13 - Tactile Feedback in CLI
 **Learning:** In terminal-based games, users expect immediate visual feedback for their actions. Relying on a periodic "tick" to update the UI creates a laggy feel. Using `poll()` with a dynamic timeout allows the application to remain idle yet wake up instantly to process and render user input.
 **Action:** Always trigger a UI refresh immediately after processing user input in CLI applications, and use efficient waiting mechanisms (like `poll`) that can be interrupted by input.
+
+## 2026-02-17 - Fair Start with Countdown and Input Flushing
+**Learning:** In time-sensitive CLI games, users often start pressing keys before the game loop begins. Providing a countdown gives them time to prepare, and flushing the input buffer (tcflush) immediately after the countdown ensures that accidental pre-game input doesn't give an unfair advantage or toggle settings unexpectedly.
+**Action:** Always pair animated countdowns with tcflush(STDIN_FILENO, TCIFLUSH) in interactive terminal applications to ensure a clean state at the start of gameplay.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,12 @@
 #include <termios.h>
 #include <algorithm>
 
+#define CLR_SCORE "\033[1;32m" // Bold Green
+#define CLR_HARD  "\033[1;31m" // Bold Red
+#define CLR_NORM  "\033[1;34m" // Bold Blue
+#define CLR_CTRL  "\033[1;33m" // Bold Yellow
+#define CLR_RESET "\033[0m"
+
 int main() {
     struct termios oldt, newt;
     tcgetattr(STDIN_FILENO, &oldt);
@@ -14,12 +20,16 @@ int main() {
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     int score = 0; bool hardMode = false; char input;
-    std::cout << YELLOW << "==========================\n      SPEED CLICKER\n==========================\n" << RESET
-              << "Controls:\n " << YELLOW << "[h]" << RESET << " Toggle Hard Mode (10x Speed!)\n "
-              << YELLOW << "[q]" << RESET << " Quit Game\n " << YELLOW << "[Any key]" << RESET << " Click!\n\n";
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET
               << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
-              << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n [Any key] Click!\n\n";
+              << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
+
+    for (int i = 3; i > 0; --i) {
+        std::cout << CLR_CTRL << "Starting in " << i << "..." << CLR_RESET << "\r" << std::flush;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    std::cout << CLR_CTRL << "GO!             " << CLR_RESET << "\r" << std::flush;
+    tcflush(STDIN_FILENO, TCIFLUSH);
 
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     auto last_tick = std::chrono::steady_clock::now();
@@ -46,9 +56,6 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << GREEN << "Score: " << score << RESET
-                      << (hardMode ? RED " [FAST]    " : BLUE " [NORMAL]  ") << RESET
-                      << "      \r" << std::flush;
             std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << "    " << std::flush;


### PR DESCRIPTION
💡 What: Added an animated 3-2-1 countdown and fixed broken UI/colors.
🎯 Why: The game started instantly, which was jarring. Also, the build was broken due to missing macros and had duplicate logic.
📸 Before/After: The game now shows "Starting in 3... 2... 1... GO!" before gameplay begins. Colors are now correctly displayed and the build is fixed.
♿ Accessibility: Improved preparedness for time-sensitive gameplay.

---
*PR created automatically by Jules for task [547313217012499272](https://jules.google.com/task/547313217012499272) started by @aidasofialily-cmd*