### PR TITLE
🎨 Palette: Improved game startup and cursor handling

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-02-13 - Tactile Feedback in CLI
 **Learning:** In terminal-based games, users expect immediate visual feedback for their actions. Relying on a periodic "tick" to update the UI creates a laggy feel. Using `poll()` with a dynamic timeout allows the application to remain idle yet wake up instantly to process and render user input.
 **Action:** Always trigger a UI refresh immediately after processing user input in CLI applications, and use efficient waiting mechanisms (like `poll`) that can be interrupted by input.
+
+## 2026-02-24 - Game Session Flow
+**Learning:** Immediate game start without a "Ready?" prompt can catch users off guard. Adding a "Press any key to start" step improves session readiness. Also, hiding the cursor during gameplay reduces visual noise and increases immersion in CLI games.
+**Action:** Always implement a start prompt and cursor hiding for interactive CLI games.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,14 +19,16 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define HIDE_CURSOR "\033[?25l"
+#define SHOW_CURSOR "\033[?25h"
 
 struct termios oldt;
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     // Use write() and _exit() because they are async-signal-safe
-    const char* msg = "\033[0m\n\nGame interrupted. Terminal settings restored.\n";
-    write(STDOUT_FILENO, msg, 52);
+    const char* msg = SHOW_CURSOR "\033[0m\n\nGame interrupted. Terminal settings restored.\n";
+    write(STDOUT_FILENO, msg, 58);
     _exit(signum);
 }
 
@@ -50,6 +52,13 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET
               << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
+
+    std::cout << "Press any key to start... (q to quit)" << std::flush;
+    if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
+        tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+        return 0;
+    }
+    std::cout << HIDE_CURSOR;
 
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     auto last_tick = std::chrono::steady_clock::now();
@@ -86,6 +95,6 @@ int main() {
         }
     }
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\nThanks for playing!\n";
+    std::cout << SHOW_CURSOR << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\nThanks for playing!\n";
     return 0;
 }


### PR DESCRIPTION
This PR improves the game session UX by:
1.  Adding a "Press any key to start..." prompt, preventing the game from starting before the user is ready.
2.  Hiding the cursor during gameplay (`\033[?25l`) to reduce visual noise.
3.  Ensuring the cursor is restored (`\033[?25h`) on both normal exit and signal interruption (Ctrl+C).

These changes align with CLI best practices for interactive applications.

---
*PR created automatically by Jules for task [7516288031507902703](https://jules.google.com/task/7516288031507902703) started by @EiJackGH*