### PR TITLE
🎨 Palette: [UX improvement] Add start prompt, countdown, and UI cleanup

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,9 @@
 ## 2026-02-13 - Tactile Feedback in CLI
 **Learning:** In terminal-based games, users expect immediate visual feedback for their actions. Relying on a periodic "tick" to update the UI creates a laggy feel. Using `poll()` with a dynamic timeout allows the application to remain idle yet wake up instantly to process and render user input.
 **Action:** Always trigger a UI refresh immediately after processing user input in CLI applications, and use efficient waiting mechanisms (like `poll`) that can be interrupted by input.
+
+## 2026-05-23 - Sequential Segmented Reading for Large Files
+
+**Learning:** Sandbox output for both `read_file` and `run_in_bash_session` is truncated at 1000 characters. To reliably inspect large source files (like `src/main.cpp`) and avoid guesswork or hallucinated review feedback, it's critical to read the file in small, sequential segments (e.g., 20 lines at a time) across multiple tool calls to ensure the entire logic is visible in the trace.
+
+**Action:** Always use segmented reading for files exceeding 1000 characters and confirm the entire file content before proposing or implementing changes.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,20 @@ int main() {
               << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
+    // Palette UX: Start prompt and animated countdown
+    std::cout << CLR_CTRL << "Press any key to start..." << CLR_RESET << std::flush;
+    if (read(STDIN_FILENO, &input, 1) <= 0 || input == 'q') {
+        tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+        return 0;
+    }
+
+    for (int i = 3; i > 0; --i) {
+        std::cout << "\r" << CLR_CTRL << "Starting in " << CLR_HARD << i << "..." << CLR_RESET << "    " << std::flush;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    std::cout << "\r" << CLR_NORM << "GO!                " << CLR_RESET << std::endl;
+    tcflush(STDIN_FILENO, TCIFLUSH);
+
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     auto last_tick = std::chrono::steady_clock::now();
     bool updateUI = true;
@@ -76,12 +90,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << GREEN << "Score: " << score << RESET
-                      << (hardMode ? RED " [FAST]    " : BLUE " [NORMAL]  ") << RESET
-                      << "      \r" << std::flush;
+            // Palette UX: Cleaned up UI update to remove redundancy and flicker
             std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << "    " << std::flush;
+                      << "          " << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
### 💡 What:
Added a "Press any key to start" prompt and a 3-second animated countdown before the game begins. Also refactored the UI update logic to remove a redundant print call that was causing flickering.

### 🎯 Why:
The game started immediately upon execution, which could catch users off guard. The countdown builds anticipation and allows for preparation. The UI refactoring ensures a smoother visual experience without redundant characters or flicker.

### 📸 Before/After:
**Before:** Game starts immediately; score updates twice per tick causing flicker.
**After:** Clear start prompt -> 3-2-1-GO countdown -> Smooth, single-line score updates.

### ♿ Accessibility:
- Added clearer status labels (e.g., [NORMAL MODE], [HARD MODE]).
- Improved timing predictability with the countdown.
- Reduced visual noise and flicker.

---
*PR created automatically by Jules for task [6539115498071985675](https://jules.google.com/task/6539115498071985675) started by @aidasofialily-cmd*