### PR TITLE
Palette: Improve CLI UX with cursor hiding and start prompt

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@ struct termios oldt;
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     // Use write() and _exit() because they are async-signal-safe
-    const char* msg = "\033[0m\n\nGame interrupted. Terminal settings restored.\n";
-    write(STDOUT_FILENO, msg, 52);
+    const char* msg = "\033[?25h\033[0m\n\nGame interrupted. Terminal settings restored.\n";
+    write(STDOUT_FILENO, msg, 58);
     _exit(signum);
 }
 
@@ -46,10 +46,19 @@ int main() {
         return 1;
     }
 
+    // Hide cursor and clear screen
+    std::cout << "\033[?25l\033[2J\033[H" << std::flush;
+
     long long score = 0; bool hardMode = false; char input;
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET
               << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
+
+    std::cout << "Press any key to start..." << std::flush;
+    if (read(STDIN_FILENO, &input, 1) < 0) {
+        perror("read");
+    }
+    std::cout << "\r" << "                         " << "\r" << std::flush;
 
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     auto last_tick = std::chrono::steady_clock::now();
@@ -86,6 +95,6 @@ int main() {
         }
     }
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\nThanks for playing!\n";
+    std::cout << "\033[?25h\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\nThanks for playing!\n";
     return 0;
 }


### PR DESCRIPTION
- Hidden the cursor during gameplay (`\033[?25l`) to reduce visual clutter.
- Added a "Press any key to start..." prompt to allow users to read instructions before the game begins.
- Cleared the screen at startup (`\033[2J\033[H`) for a cleaner initial state.
- Ensured cursor is restored (`\033[?25h`) on normal exit and interrupt (SIGINT/SIGTERM).
- Updated signal handler message length to correctly handle the new escape sequence.
- Verified using `script` to simulate a TTY and capture output.

---
*PR created automatically by Jules for task [10828961744473044530](https://jules.google.com/task/10828961744473044530) started by @EiJackGH*