### PR TITLE
🎨 Palette: Add Start Prompt and Animated Countdown

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-02-13 - Tactile Feedback in CLI
 **Learning:** In terminal-based games, users expect immediate visual feedback for their actions. Relying on a periodic "tick" to update the UI creates a laggy feel. Using `poll()` with a dynamic timeout allows the application to remain idle yet wake up instantly to process and render user input.
 **Action:** Always trigger a UI refresh immediately after processing user input in CLI applications, and use efficient waiting mechanisms (like `poll`) that can be interrupted by input.
+
+## 2026-10-27 - Transitioning to Active Gameplay in CLI
+**Learning:** In time-sensitive CLI games, starting immediately upon launch or after a single keypress can be jarring. A "Press any key to start" prompt followed by a 3-second animated countdown provides a clear transition, allows the user to prepare their hands, and signals the switch from reading instructions to active play.
+**Action:** Implement a responsive countdown (3-2-1-GO) for CLI games to improve user readiness and game-start fairness.


### PR DESCRIPTION
### 💡 What
Added a "Press any key to start" prompt and a 3-second animated countdown (3... 2... 1... GO!) before the game begins. Also unified the UI rendering logic to prevent flickering and standardized on the `CLR_*` color macros.

### 🎯 Why
The game previously started immediately or without a clear transition from the menu/instructions. This was jarring for users and didn't allow them time to prepare their hands for a speed-clicking task.

### 📸 Before/After
**Before:** The game would show instructions and wait for a single tick or input to show the score line immediately.
**After:** 
1. `Press any key to start...`
2. `Starting in 3...` -> `Starting in 2...` -> `Starting in 1...` -> `Starting in GO!`
3. Clean, consistent score UI.

### ♻️ Accessibility
- Added clear visual cues for game state transitions.
- The countdown is responsive and can be interrupted by the quit key ('q'), ensuring the user is never "trapped" in an animation.
- Used high-contrast bold colors for important status indicators.

---
*PR created automatically by Jules for task [5591575676298189231](https://jules.google.com/task/5591575676298189231) started by @aidasofialily-cmd*