### PR TITLE
🎨 Palette: Improved game start experience and UI polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-02-13 - Tactile Feedback in CLI
 **Learning:** In terminal-based games, users expect immediate visual feedback for their actions. Relying on a periodic "tick" to update the UI creates a laggy feel. Using `poll()` with a dynamic timeout allows the application to remain idle yet wake up instantly to process and render user input.
 **Action:** Always trigger a UI refresh immediately after processing user input in CLI applications, and use efficient waiting mechanisms (like `poll`) that can be interrupted by input.
+
+## 2026-05-23 - Ensuring a Fair Start in CLI Games
+**Learning:** Users often spam keys during a game's countdown phase in anticipation. If these inputs are buffered and processed immediately when the game starts, it can lead to an unfair advantage or accidental actions. Using `tcflush(STDIN_FILENO, TCIFLUSH)` after the countdown ensures the game starts with a clean slate.
+**Action:** Always clear the input buffer with `tcflush` after a blocking countdown or transition period in interactive CLI applications to ensure intent-based interaction.


### PR DESCRIPTION
### 💡 What
This PR adds a more polished game start sequence to SPEED CLICKER. It introduces a "Press any key to start" prompt followed by an animated "3... 2... 1... GO!" countdown. Additionally, it refactors the UI update logic in the main loop to be more efficient and consistent.

### 🎯 Why
Starting the game immediately after execution can be jarring, especially for new players or when the game is in hard mode. The new sequence provides a clear transition from instruction-reading to active gameplay.

### 📸 Before/After
- **Before:** Game starts immediately upon execution, printing scores as the timer ticks.
- **After:** Game waits for a keypress, then displays a 1-second interval countdown (3, 2, 1) before shouting "GO!" and starting the score tracking.

### ♿ Accessibility
- Provides a predictable start mechanism.
- Includes a `tcflush` call after the countdown to ensure that frantic keypresses during the animation don't result in accidental game actions, ensuring the game starts only when the user is ready.
- Maintains high-contrast ANSI colors for status indicators.

---
*PR created automatically by Jules for task [4209051203107821340](https://jules.google.com/task/4209051203107821340) started by @aidasofialily-cmd*