### PR TITLE
🎨 Palette: Hide cursor during gameplay for better UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-05-25 - DX as UX: Clean Builds for CI/CD
 **Learning:** In a C++ project, the build process is the foundation of the Developer Experience. A broken build not only prevents local development but also paralyzes automated CI/CD workflows like CodeQL analysis. Resolving redundant logic and compilation errors (like duplicate variable declarations) is essential for maintaining a healthy project and enabling advanced security scanning.
 **Action:** Prioritize clean, warning-free compilation and utilize helper functions to consolidate redundant logic, ensuring both developers and CI tools can interact with the codebase seamlessly.
+
+## 2026-03-06 - Hide Cursor During CLI Gameplay
+**Learning:** Failing to hide the cursor during rapid terminal updates causes distracting blinking and visual clutter, reducing the quality of the CLI interaction.
+**Action:** Always use ANSI escape sequences (like `\033[?25l`) coupled with `std::flush` to hide the cursor during interactive CLI sessions, and ensure it is reliably restored on exit.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,8 @@ int main() {
         return 1;
     }
 
+    std::cout << HIDE_CURSOR << std::flush;
+
     long long highscore = load_highscore();
     long long score = 0;
     bool hardMode = false;
@@ -123,7 +125,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << SHOW_CURSOR << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
 
     if (score > highscore) {
         std::cout << CLR_NORM << "NEW HIGH SCORE! " << CLR_RESET << "Previous was " << highscore << "\n";


### PR DESCRIPTION
💡 What: Added ANSI escape sequences (`HIDE_CURSOR`) to hide the terminal cursor during gameplay and (`SHOW_CURSOR`) to restore it on exit.
🎯 Why: Hiding the cursor during rapid terminal updates prevents distracting blinking and visual clutter, significantly reducing visual noise and improving the CLI interaction quality.
📸 Before/After: N/A
♿ Accessibility: Reduces visual distraction and flickering for all users, leading to a more comfortable, focused experience.

---
*PR created automatically by Jules for task [8655777254328478191](https://jules.google.com/task/8655777254328478191) started by @EiJackGH*