### PR TITLE
🎨 Palette: Fix visual artifacts in CLI updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-06-15 - Erasing in Line for Dynamic Output
+**Learning:** Hardcoding spaces to clear shorter text that follows longer text when returning to the beginning of the line (`\r`) is unreliable and can leave visual artifacts. Using `\033[K` (Erase in Line) immediately after `\r` cleanly clears the remaining characters from the previous output.
+**Action:** Use the `\033[K` ANSI sequence whenever updating a dynamic terminal line via `\r` instead of hardcoding padding spaces to ensure a clean UI and prevent trailing text artifacts.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,7 +91,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -105,7 +105,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -134,10 +134,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Added the `\033[K` ANSI escape sequence after every `\r` (carriage return) that overwrites previously printed longer strings in the main gameplay loop and countdown sequences, effectively removing the need for manual space padding.
🎯 Why: In terminal environments, when updating a line via a carriage return, printing a shorter string over a longer string leaves visual artifacts (the end characters of the previous string). Hardcoded padding is error-prone. The `\033[K` (Erase in Line) sequence provides a reliable UX improvement to maintain a clean interface.
📸 Before/After: Visual artifacts removed from countdown overlapping and from final score rendering. 
♿ Accessibility: N/A - Terminal output polish.

---
*PR created automatically by Jules for task [8109902391694105067](https://jules.google.com/task/8109902391694105067) started by @EiJackGH*