### PR TITLE
🎨 Palette: Hide cursor during gameplay and clean up line rendering

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+## 2024-05-24 - Cursor Visibility in CLI Games
+**Learning:** Terminal cursors blinking over dynamic game output creates visual noise and distraction.
+**Action:** Always use the `\033[?25l` (hide cursor) and `\033[?25h` (show cursor) ANSI escape sequences around interactive terminal applications, ensuring it's properly flushed to the output.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,8 @@ int main() {
     std::signal(SIGINT, restore_terminal);
     std::signal(SIGTERM, restore_terminal);
 
+    std::cout << "\033[?25l" << std::flush;
+
     newt = oldt;
     newt.c_lflag &= ~(ICANON | ECHO);
     if (tcsetattr(STDIN_FILENO, TCSANOW, &newt) == -1) {
@@ -73,15 +75,6 @@ int main() {
     long long score = 0;
     bool hardMode = false;
     char input;
-
-    long long highscore = 0;
-    std::ifstream infile("highscore.txt");
-    if (infile.is_open()) {
-        infile >> highscore;
-        infile.close();
-    }
-
-    long long score = 0; bool hardMode = false; char input;
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
@@ -145,20 +138,14 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }
 
-    if (score > highscore) {
-        std::ofstream outfile("highscore.txt");
-        if (outfile.is_open()) {
-            outfile << score;
-            outfile.close();
-        }
     if (score > initialHighscore) {
         save_highscore(score);
     }


### PR DESCRIPTION
🎨 Palette UX Enhancement:

💡 What:
- Hides the terminal cursor (`\033[?25l`) while the game is running and restores it (`\033[?25h`) upon normal exit and signal interruptions.
- Uses Erase in Line (`\033[K`) to clean up trailing characters instead of padding with space characters when displaying score updates.

🎯 Why:
- A blinking cursor moving rapidly across dynamic game output creates visual noise and distraction. Hiding it provides a cleaner, more immersive experience.
- Using the standard Erase in Line ANSI sequence ensures reliable removal of trailing content without needing to guess required padding width or sending extra unnecessary bytes to the terminal.

♿ Accessibility:
- Reduces visual clutter which can be confusing for some users when a static cursor position is repeatedly redrawn.

(Note: fixed the previously malformed file modification that deleted `highscore` file writing logic).

---
*PR created automatically by Jules for task [408994212345541848](https://jules.google.com/task/408994212345541848) started by @EiJackGH*