### PR TITLE
\ud83c\udfa8 Palette: Enhance CLI game visual feedback and achievement logic

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << "             \n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -138,8 +138,8 @@ int main() {
 
         if (updateUI) {
             std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_CTRL " NEW BEST! 🥳" CLR_RESET : "")
                       << "           " << std::flush;
             updateUI = false;
         }
@@ -151,8 +151,8 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
-        std::cout << "Congratulations! A new personal best!\n";
+    if (score > initialHighscore) {
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR implements several micro-UX improvements to the SPEED CLICKER CLI game to enhance visual feedback and player delight:

\ud83d\udca1 **What**: 
- Color-coded the countdown digits with Bold Yellow (`CLR_CTRL`).
- Color-coded the "GO!" prompt with Bold Green (`CLR_NORM`).
- Updated the "NEW BEST! \ud83e\udd73" live indicator and final congratulatory message to appear for first-time players (surpassing 0) as well as returning players.
- Added proper `CLR_RESET` after the `[HARD MODE]` and `[NORMAL MODE]` indicators.

\ud83c\udfaf **Why**: 
- The countdown was plain text, making it less engaging. Color highlights draw the user's attention to the start of the action.
- First-time players previously didn't see any "New Best" celebration, which is a missed opportunity for positive reinforcement.
- Missing color resets caused visual inconsistency in some terminal environments.

\u267b\ufe0f **Verification**:
- Built with `make`.
- Ran `verify_ux.py` to ensure cursor management is intact.
- Conducted headless pty tests to verify ANSI escape sequences for all new colors and the updated logic.


---
*PR created automatically by Jules for task [4004666581298833465](https://jules.google.com/task/4004666581298833465) started by @aidasofialily-cmd*