### PR TITLE
🎨 Palette: Prevent trailing text artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2024-05-23 - Preventing Trailing Text Artifacts in Dynamic CLI
+**Learning:** When using carriage returns (`\r`) to overwrite the current line in a terminal, any old text that is longer than the new text will remain on the screen as trailing artifacts. Attempting to fix this by hardcoding padding spaces is fragile and depends on guessing the maximum possible length of previous output.
+**Action:** Always use the ANSI "Erase in Line" escape sequence (`\033[K`) immediately after a carriage return (`\r\033[K`) to dynamically clear the remaining line content before printing new text.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
### 💡 What: 
Added the ANSI "Erase in Line" escape sequence (`\033[K`) to all dynamic text outputs in `src/main.cpp` that overwrite the current line using a carriage return (`\r`).

### 🎯 Why: 
When updating a dynamic terminal line (like a timer or live score), trailing text from previously longer strings can linger as a messy visual artifact if the new text is shorter. Previously, the code tried to prevent this by manually hardcoding extra blank spaces (e.g. `<< "           " << std::flush`), which is fragile and guesses output length. 

Using `\033[K` is the robust, standard way to tell the terminal to cleanly delete everything from the cursor's position to the end of the line, keeping the interface crisp and focused.

### 📸 Before/After: 
* **Before:** `\rGO!             ` (Relying on spaces to clear "Starting in 1...")
* **After:** `\r\033[KGO!` (Cleanly wiping the rest of the line)

### ♿ Accessibility / UX: 
Reduces visual clutter and prevents "ghost" characters from confusing the player during dynamic events, creating a more professional, tactile feel to the game. 

(Also updated the `.Jules/palette.md` journal with this learning!)

---
*PR created automatically by Jules for task [13706607413635797423](https://jules.google.com/task/13706607413635797423) started by @EiJackGH*