### PR TITLE
🎨 Palette: Micro-UX improvements for Speed Clicker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,11 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2024-05-23 - Inclusive Achievement Celebrations
+**Learning:** Hard-coding achievement triggers to require a non-zero previous best (e.g., `initialHighscore > 0`) accidentally excludes first-time users from experiencing the "delight" of their first victory. A "NEW BEST!" should trigger whenever the current score exceeds the previous record, even if that record was zero.
+**Action:** Always ensure achievement logic is inclusive of first-time players by comparing against the base state without arbitrary "greater than zero" requirements.
+
+## 2024-05-23 - Live High Score Motivation
+**Learning:** In competitive or performance-based CLI games, showing only the current score creates a "blind" experience. Displaying the current high score (the target) in real-time alongside the active score provides immediate context, motivation, and a clearer sense of progress.
+**Action:** Implement a "Target/Best" display in the HUD of interactive CLI tools to provide real-time performance feedback.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | "
+                      << "High: " << std::max(score, initialHighscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+                      << "           " << CLR_RESET << std::flush;
             updateUI = false;
         }
     }
@@ -151,7 +152,7 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
+    if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }
     std::cout << "Thanks for playing!\n";


### PR DESCRIPTION
- 💡 What: Added several micro-UX enhancements to the Speed Clicker game:
    - Colorized the countdown numbers with Bold Yellow (`CLR_CTRL`) and the "GO!" prompt with Bold Green (`CLR_NORM`).
    - Updated the live HUD to show both current score and high score (`Score: X | High: Y`).
    - Fixed logic that prevented "NEW BEST!" and "Congratulations" from appearing for first-time players.
    - Added `CLR_RESET` to the end of volatile HUD lines to prevent color leaking.
- 🎯 Why: To make the game more engaging, provide better feedback, and ensure first-time players feel celebrated.
- ♿ Accessibility: Improved visual feedback and ensured proper terminal state management (added color resets).

---
*PR created automatically by Jules for task [5302052156726224690](https://jules.google.com/task/5302052156726224690) started by @aidasofialily-cmd*