### PR TITLE
🎨 Palette: Enhance CLI UX by preventing text artifacts with ANSI line erase

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-10 - Preventing Text Artifacts in Dynamic Terminal Lines
+**Learning:** Hardcoding padding spaces to overwrite old, longer text strings in dynamic terminal lines (e.g., using `\r`) is fragile and can lead to trailing text artifacts. It fails when the old string is significantly longer or terminal resizing occurs.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return `\r` when updating dynamic text elements like scoreboards or countdowns to ensure a clean line redraw.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
### 💡 What
This PR replaces brittle string padding logic ("    ") used when overwriting dynamic terminal lines with standard ANSI escape sequences for Erase in Line (`\033[K`).

### 🎯 Why
When updating terminal lines dynamically using carriage returns (`\r`), relying on hardcoded spaces to erase previous characters can lead to visual artifacts when string lengths change or terminals get resized. Using ANSI line erase guarantees a clean UI redraw, especially in rapid updating loops like countdowns and score tracking.

### ♿ Accessibility/UX
Ensures that no visual clutter is left behind on the terminal buffer, creating a smoother and more robust user experience for the CLI application.

---
*PR created automatically by Jules for task [6879524848299576450](https://jules.google.com/task/6879524848299576450) started by @EiJackGH*