### PR TITLE
🎨 Palette: Prevent trailing text artifacts in dynamic CLI updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2024-06-25 - Preventing Trailing Artifacts in CLI Dynamics
+**Learning:** When creating dynamic, single-line updates in a terminal using ``, old text can trail behind the new text if the new text is shorter. Instead of hardcoding padding spaces—which is error-prone and can cause word-wrap issues on smaller terminals—using the ANSI escape sequence `[K` (Erase in Line) immediately after the carriage return ensures a clean slate for the new frame.
+**Action:** Use `[K` after `` in CLI applications whenever overwriting the current line to guarantee clean dynamic updates without trailing text artifacts.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: 
Added the ANSI escape sequence `\033[K` (Erase in Line) after carriage returns (`\r`) in the dynamic terminal UI, replacing hardcoded padding spaces.

🎯 Why: 
When updating a single line in a terminal with new, shorter text, the end of the older, longer text is typically left visible unless padding spaces are used. However, padding spaces are a fragile solution, particularly when the exact length needed is variable or when dealing with smaller terminal sizes where word wrap might occur. Utilizing the `\033[K` escape sequence ensures a mathematically clean update, completely erasing any text from the cursor position to the end of the line, guaranteeing no trailing artifacts and maintaining a pristine view.

📸 Before/After: 
N/A (This fixes potential rendering artifacts, making dynamic strings like the countdown or score shorter/longer robust on line changes).

♿ Accessibility/UX: 
Provides a much cleaner and glitch-free real-time updating experience for users interacting with the terminal application, ensuring that score and status updates are consistently legible and professionally displayed regardless of terminal width.

**Testing details:**
Tests passing (`make`, `verify_ux.py`, and `test_bitcoin.py`). Removed temporary `output.log` from test captures so it is not tracked in VC.

---
*PR created automatically by Jules for task [9530679294071667356](https://jules.google.com/task/9530679294071667356) started by @EiJackGH*