### PR TITLE
🎨 Palette: Prevent trailing text artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-06-15 - Preventing Trailing Artifacts in CLI
+**Learning:** Hardcoding padding spaces to overwrite previous dynamic text outputs (using `\r`) is fragile and can lead to trailing artifacts or messy code if the text length shrinks or varies unpredictably.
+**Action:** Use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return `\r` to cleanly clear the line from the cursor to the end, removing the need for hardcoded space padding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Replaced hardcoded space padding in the CLI output updates with the ANSI escape sequence `\033[K` (Erase in Line).

🎯 Why: To make the text replacement more robust when updating lines in a terminal UI. Hardcoding spaces fails when the length of dynamic text changes unpredictably, leaving trailing artifacts. `\033[K` natively clears from the cursor to the end of the line.

♿ Accessibility/UX: Provides a cleaner, glitch-free UI without text flickering or residual characters from longer strings when rendering updates to the screen.

---
*PR created automatically by Jules for task [13583505374013509044](https://jules.google.com/task/13583505374013509044) started by @EiJackGH*