### PR TITLE
🎨 Palette: Erase Dynamic Lines using ANSI \033[K

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-06-15 - Dynamic Terminal Line Erasing
+**Learning:** Hardcoded padding spaces to overwrite older, longer text lines in a dynamic terminal application (like when outputting a shorter string via `\r`) are brittle and leave trailing artifacts.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately following a carriage return (`\r`) to ensure a clean visual reset for dynamic lines.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: The UX enhancement added an ANSI escape sequence `\033[K` to clear the terminal line when text is updated dynamically via carriage return `\r`. 
🎯 Why: The user problem it solves is preventing "trailing artifacts" where a longer string on the line isn't fully overwritten by a shorter new string. The old approach of hardcoding 11-15 spaces after the string was brittle and error-prone.
📸 Before/After: Not applicable (invisible visual polish that prevents artifacts from forming).
♿ Accessibility: N/A, but improves visual coherence of the UI.

---
*PR created automatically by Jules for task [1136015281669970418](https://jules.google.com/task/1136015281669970418) started by @EiJackGH*