### PR TITLE
🎨 Palette: Prevent terminal output artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-14 - Preventing Terminal Output Artifacts
+**Learning:** When dynamically updating text in a CLI application on the same line (using `\r`), simply overwriting with new text or appending a fixed number of spaces can lead to "ghost" characters if the new string is shorter than the previous one. The previous text's tail isn't erased, creating confusing visual artifacts.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return `\r` (e.g., `\r\033[K`) to definitively clear the line from the cursor position to the end. This ensures the line is pristine before writing new content, providing a clean and reliable UX without resorting to hardcoded padding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** 
Added the ANSI escape sequence `\033[K` (Erase in Line) immediately following carriage returns (`\r`) when dynamically updating text in the CLI.

🎯 **Why:** 
Previously, the terminal UI relied on appending hardcoded whitespace (e.g., `"           "`) to overwrite any remaining characters from previous, longer strings. If the previous string was significantly longer, or if the terminal was resized, this could lead to confusing visual artifacts ("ghost" characters). Using `\033[K` definitively clears the line from the cursor to the end, ensuring a pristine canvas for the new text update.

📸 **Before/After:**
*Before:* Terminal output could sometimes show trailing characters if a previous message was longer than the current message and the hardcoded padding wasn't sufficient.
*After:* The terminal line is explicitly cleared, guaranteeing clean output regardless of the previous string length.

♿ **Accessibility:**
Provides a more consistent and reliable visual experience by preventing confusing on-screen artifacts that might distract or mislead users.

---
*PR created automatically by Jules for task [15829543352009975548](https://jules.google.com/task/15829543352009975548) started by @EiJackGH*