### PR TITLE
🎨 Palette: Use `\033[K` to clear trailing artifacts on dynamic CLI lines

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-15 - Erasing Trailing Artifacts
+**Learning:** To prevent trailing text artifacts in CLI applications when updating dynamic terminal lines via '\r', using the ANSI escape sequence '\033[K' (Erase in Line) immediately after the carriage return is cleaner and more reliable than hardcoding padding spaces.
+**Action:** Use '\033[K' to clear the current line after '\r' for dynamic UI elements in all CLI applications.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Added the `\033[K` ANSI sequence (Erase in Line) immediately after a carriage return `\r` on dynamic output lines to cleanly erase previous characters without relying on hardcoded padding spaces. Updated `.Jules/palette.md` to log this critical learning.
🎯 Why: In CLI applications, updating lines in place dynamically with `\r` leaves trailing text behind when the new line is shorter than the previous line. Padding with whitespace is hacky and error-prone. `\033[K` provides a robust fix.
📸 Before/After: N/A, UI visual consistency is improved for string lengths that shrink dynamically.
♿ Accessibility: Ensures crisp and predictable visual text updates for users without visual artifacts.

---
*PR created automatically by Jules for task [12488439202030388727](https://jules.google.com/task/12488439202030388727) started by @EiJackGH*