### PR TITLE
🎨 Palette: Enhance game start feedback and high score celebration visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2024-06-18 - Inclusive Achievement Feedback
+**Learning:** Achievement celebrations (like "NEW BEST!") should be inclusive of the very first success. Initializing logic that requires a pre-existing non-zero high score (`initialHighscore > 0`) prevents first-time players from experiencing immediate positive reinforcement when they set their very first record.
+**Action:** Always check against the starting state (e.g., `score > initialHighscore`) regardless of whether the initial state is zero, to ensure delight is delivered from the first interaction.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << initialHighscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+                      << CLR_RESET << "           " << std::flush;
             updateUI = false;
         }
     }
@@ -151,7 +151,7 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
+    if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }
     std::cout << "Thanks for playing!\n";


### PR DESCRIPTION
### 💡 What: The UX enhancement added
- **Enhanced Visual Feedback:** The pre-game countdown and "GO!" prompt are now colorized (Bold Yellow and Bold Green respectively) to provide clearer state transitions and engagement.
- **Real-time Goal Tracking:** Added the Personal Best high score to the live gameplay UI (`Score: X | High: Y`).
- **Inclusive Celebrations:** Fixed a logic bug where "NEW BEST!" and congratulatory messages only appeared if a high score already existed. Now, first-time players are celebrated when they set their very first record.
- **Terminal Hygiene:** Added `CLR_RESET` to the end of carriage-returned lines to prevent ANSI color leakage.

### 🎯 Why: The user problem it solves
- **Lack of immediate goal context:** Players previously had to remember their high score from the menu; now it's visible during play.
- **Missing first-time delight:** New players didn't get the "NEW BEST!" dopamine hit on their first successful run.
- **Flat visual experience:** The game start felt a bit static; colorized cues improve the "arcade" feel.

### ♿ Accessibility: Any a11y improvements made
- Improved visual hierarchy by using standard color macros for critical game states.
- Ensured terminal state consistency by explicitly resetting colors on volatile lines.

---
*PR created automatically by Jules for task [18143137158913886899](https://jules.google.com/task/18143137158913886899) started by @aidasofialily-cmd*