### PR TITLE
🎨 Palette: Enhance CLI UX by clearing dynamic lines with \033[K

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-06-15 - Erase in Line (`\033[K`) for clean terminal updates
+**Learning:** When updating a terminal line dynamically using a carriage return (`\r`), relying on hardcoded padding spaces to overwrite old content is fragile and messy. If the new string is shorter than the old one, the trailing characters from the previous string remain visible, leading to visual artifacts.
+**Action:** Use the ANSI escape sequence `\033[K` (Erase in Line) immediately after `\r`. This clears the line from the cursor to the end, ensuring that whatever follows is printed on a clean slate.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
I replaced hardcoded padding spaces with the ANSI escape sequence `\033[K` (Erase in Line) immediately following `\r` updates in `src/main.cpp`. This ensures the terminal output stays perfectly clean dynamically, avoiding trailing text artifacts without having to manually pad strings. A journal entry has been recorded in `.Jules/palette.md` detailing this terminal UX interaction learning. Added standard `venv/` to `.gitignore` to prevent committing virtual environments.

---
*PR created automatically by Jules for task [2466608622044937259](https://jules.google.com/task/2466608622044937259) started by @EiJackGH*