### PR TITLE
🎨 Palette: Replace hardcoded spaces with \033[K to prevent terminal artifacts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-05-25 - Clean UI Updates in CLI
+**Learning:** Hardcoded padding spaces to overwrite old text in a CLI loop often lead to trailing artifacts if the new text is shorter than the old. Using the ANSI escape sequence `\033[K` (Erase in Line) immediately after `\r` (Carriage Return) cleanly clears the line from the cursor to the end, preventing visual glitches.
+**Action:** Use `\r\033[K` for dynamic single-line updates in all terminal UI components to ensure clean rendering.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced hardcoded padding spaces with the ANSI escape sequence `\033[K` (Erase in Line) immediately after `\r` (Carriage Return) in the dynamic terminal update loops within `src/main.cpp`.

🎯 **Why:** In dynamic terminal loops, writing shorter lines over longer lines can leave trailing text artifacts. Hardcoding space padding is a fragile guessing game. Using the standard `\033[K` escape sequence cleanly and robustly clears the line from the cursor to the end, resulting in a significantly more polished and artifact-free user experience. This prevents visual glitches as scores or states change rapidly.

📸 **Before/After:** The game score and countdown displays will no longer occasionally flash trailing spaces or characters if the line length fluctuates.

♿ **Accessibility:** This is a visual polish and developer experience improvement, ensuring clean rendering for users playing the game or running the application via CLI.

---
*PR created automatically by Jules for task [1591788124006896186](https://jules.google.com/task/1591788124006896186) started by @EiJackGH*