### PR TITLE
🎨 Palette: Use ANSI Erase in Line for dynamic terminal output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2024-05-24 - Dynamic Terminal Lines
+**Learning:** When updating dynamic terminal lines via carriage return (`\r`), hardcoded spaces are unreliable and can leave trailing artifacts, especially when text length changes (e.g., from longer 'NEW BEST!' to standard text).
+**Action:** Use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to reliably clear the line before rewriting content.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Replaced hardcoded padding spaces with the ANSI `\033[K` (Erase in Line) sequence when updating dynamic terminal text via carriage returns (`\r`).
🎯 Why: To prevent visual trailing artifacts. When text changes from a longer string (like one including "NEW BEST!") back to a shorter one, hardcoded spaces are unreliable and can leave remnant characters on the screen. `\033[K` natively and reliably clears the line from the cursor position to the end.
♿ Accessibility/UX: Provides a cleaner, glitch-free visual experience during rapid, dynamic terminal updates.

---
*PR created automatically by Jules for task [5170001371533585164](https://jules.google.com/task/5170001371533585164) started by @EiJackGH*