### PR TITLE
🎨 Palette: Clean up dynamic terminal output via ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-06-15 - Erasing Dynamic Output in CLI
+**Learning:** Hardcoding spaces to clear trailing text when dynamically updating lines (like progress bars or score counters using `\r`) can leave visual artifacts if the string length reduces significantly and the hardcoded padding isn't sufficient. It is also an anti-pattern that creates messy string formatting.
+**Action:** Use the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return `\r` to clear the line before printing new dynamic output.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
* 💡 **What:** Replaced the anti-pattern of hardcoded trailing spaces used to clear dynamic terminal output lines with the standard ANSI escape sequence `\033[K` (Erase in Line). This was updated in `src/main.cpp` for the countdown, "GO!" print, and the main game score output loop.
* 🎯 **Why:** Dynamically updating CLI lines via carriage return (`\r`) requires clearing previous longer strings. Padding with spaces is fragile and messy, leaving visual artifacts if the new string length is significantly shorter. Using `\033[K` immediately clears the line cleanly and deterministically.
* 📸 **Before/After:** No visual difference assuming the spaces were always perfectly long enough; however, under the hood, the UX is robust and artifact-free regardless of string length.
* ♿ **Accessibility/UX:** Improves general visual interactions and ensures clean screen redraws in the CLI environment, reducing cognitive load from potential UI glitches. Recorded this learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [18187167964531317196](https://jules.google.com/task/18187167964531317196) started by @EiJackGH*