### PR TITLE
🎨 Palette: Enhance CLI UX with colors and inclusive high score tracking

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-05-24 - Inclusive Achievement Feedback in CLI Games
+**Learning:** Real-time feedback for achievements (like "NEW BEST! 🥳") should be inclusive of first-time players. Relying on a non-zero initial high score to trigger celebration messages excludes the very first moment of success a new player experiences. Displaying a live high score (e.g., `Score: X | High: max(X, record)`) provides immediate context and a target for the player.
+**Action:** Ensure achievement logic triggers for first-time players by checking if `current_score > initial_high_score` (even if zero) and provide live targets in the UI.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,9 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | "
+                      << "High: " << std::max(score, initialHighscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
                       << "           " << std::flush;
             updateUI = false;
         }
@@ -151,8 +152,8 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
-        std::cout << "Congratulations! A new personal best!\n";
+    if (score > initialHighscore) {
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
I've implemented several micro-UX improvements to the SPEED CLICKER game to make it more delightful and inclusive:

1.  **Visual Delight**: The pre-game countdown and "GO!" prompt are now colorized (Bold Yellow and Bold Green), providing a much more engaging transition into the game.
2.  **Immediate Feedback**: During gameplay, players now see their current high score live (`Score: X | High: Y`). This provides immediate context for their progress.
3.  **Inclusivity for New Players**: I fixed a logic bug where the "NEW BEST! 🥳" message and final congratulations would only show if the player *already* had a recorded high score. Now, every player's first successful game is celebrated.
4.  **UI Polish**: Colorized the achievement messages to make them stand out.
5.  **UX Journal**: Added a new entry to the Palette journal reflecting on the importance of inclusive achievement feedback for first-time players.

Tested via `make`, `verify_ux.py`, and manual terminal output inspection using a pseudo-terminal.

---
*PR created automatically by Jules for task [17859890407146585244](https://jules.google.com/task/17859890407146585244) started by @aidasofialily-cmd*