### PR TITLE
🎨 Palette: Improve dynamic CLI text rendering with \033[K

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-06-03 - Preventing Text Artifacts in CLI UI Updates
+**Learning:** When dynamically updating terminal lines using carriage returns (``), older longer text can leave trailing artifacts if the new text is shorter. Relying on hardcoded padding spaces is fragile and hard to maintain.
+**Action:** Always use the ANSI 'Erase in Line' sequence (`[K`) immediately after the carriage return to cleanly clear the line before rendering the new state, ensuring a crisp UI without trailing artifacts.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: The UX enhancement replaces hardcoded whitespace padding with the ANSI "Erase in Line" escape sequence (`\033[K`) for dynamic CLI updates (timer, score). Added UX learning to `.Jules/palette.md`.
🎯 Why: It solves the trailing text artifact issue in terminal applications. When a new shorter string overwrites a longer string via `\r`, characters from the longer string remain. Hardcoded spaces are fragile and unmaintainable.
♿ Accessibility: Ensures a crisp and artifact-free UI, improving readability and overall terminal aesthetic.

---
*PR created automatically by Jules for task [12137285241687505253](https://jules.google.com/task/12137285241687505253) started by @EiJackGH*