### PR TITLE
🎨 Palette: Improve countdown feedback and high-score visibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-05-24 - Inclusive Achievement Feedback and Real-time Goal Visibility
+**Learning:** For first-time users, the absence of initial data (like a high score of 0) should not block the feedback loop for achievements. Triggering celebrations like "NEW BEST!" as soon as the first point is scored provides immediate delight. Additionally, displaying the "target" (the current high score) in real-time next to the active score provides a constant sense of progression and challenge.
+**Action:** Always ensure achievement logic handles "zero-state" starts gracefully to include new users, and provide persistent visibility of performance targets in live UIs.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,9 +137,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            if (score > highscore) highscore = score;
+            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | "
+                      << "High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
                       << "           " << std::flush;
             updateUI = false;
         }
@@ -151,7 +153,7 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
+    if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }
     std::cout << "Thanks for playing!\n";


### PR DESCRIPTION
I've implemented several micro-UX improvements to the SPEED CLICKER game to make it more engaging and rewarding, especially for new players.

Key improvements:
- **Visual Polish**: The countdown digits (3, 2, 1) are now highlighted in yellow, and the "GO!" prompt is green, creating a clearer transition from the menu to gameplay.
- **Immediate Feedback**: New players now see the "NEW BEST! 🥳" indicator as soon as they score their first point, providing immediate positive reinforcement that was previously hidden for first sessions.
- **Persistent Goal Visibility**: The session's high score is now displayed in real-time next to the current score, so players always know how close they are to beating their record.
- **Inclusive Congratulations**: First-time players now receive the final "Congratulations! A new personal best!" message, ensuring a delightful first-run experience.

These changes were implemented in `src/main.cpp` and verified using non-interactive terminal tests. Accessibility and core UX (like cursor hiding) were preserved.

---
*PR created automatically by Jules for task [10165045485918488442](https://jules.google.com/task/10165045485918488442) started by @aidasofialily-cmd*