### PR TITLE
🎨 Palette: Use Erase in Line ANSI escape sequence for dynamic text updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+## 2026-03-22 - Erase in Line with ANSI escape sequence
+**Learning:** Using `\033[K` after `\r` efficiently clears dynamic terminal lines, preventing trailing text artifacts without needing hardcoded spaces.
+**Action:** Always use `\033[K` (Erase in Line) immediately after the carriage return `\r` instead of hardcoding padding spaces.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What**: Replaced hardcoded space padding in dynamic CLI text lines with the `\033[K` ANSI escape sequence (Erase in Line).

🎯 **Why**: When replacing text "in-place" using carriage returns (`\r`), using a standard number of trailing spaces to overwrite prior longer text strings is brittle and can lead to trailing text artifacts or misaligned outputs. The `\033[K` sequence is universally supported, cleaner, and strictly clears everything to the end of the line.

📸 **Before/After**: Lines like `std::cout << "\rStarting in " << i << "... " << std::flush;` now read `std::cout << "\r\033[KStarting in " << i << "... " << std::flush;` removing the need for `\rGO!             \n`.

♿ **Accessibility**: Makes terminal output visually cleaner, improving the developer/user experience.

---
*PR created automatically by Jules for task [2984860792457747515](https://jules.google.com/task/2984860792457747515) started by @EiJackGH*