### PR TITLE
🎨 Palette: Improved CLI Feedback and Inclusive Achievements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-22 - Inclusive Achievements and Clean Terminal Updates
+**Learning:** Forgetting to celebrate first-time achievements (e.g., using `score > highscore && highscore > 0`) excludes new players from early delight. Also, in-place terminal updates using `\r` can leave "ghost" characters if the new line is shorter than the old one; the ANSI escape sequence `\033[K` (Erase in Line) is essential for a clean UI.
+**Action:** Always make achievement logic inclusive of first-time records and use `\033[K` when performing in-place terminal updates.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #define CLR_HARD  "\033[1;31m"
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
+#define CLR_ERASE "\033[K"
 #define CLR_RESET "\033[0m"
 
 struct termios oldt;
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_ERASE << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << CLR_ERASE << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +138,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << std::max(score, initialHighscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+                      << CLR_ERASE << CLR_RESET << std::flush;
             updateUI = false;
         }
     }
@@ -151,7 +152,7 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
+    if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }
     std::cout << "Thanks for playing!\n";


### PR DESCRIPTION
This PR implements several micro-UX improvements to the SPEED CLICKER CLI game:

1. **Clean Terminal Updates**: Added the `\033[K` ANSI escape sequence to the `\r` (carriage return) output lines. This ensures that when the UI updates in-place, any "ghost" characters from previous, longer lines are properly erased, providing a polished and professional look.
2. **Visual Feedback**: The countdown digits are now highlighted in Bold Yellow, and the "GO!" prompt is displayed in Bold Green, making the start of the game more engaging and clear.
3. **Real-time Motivation**: The gameplay UI now displays the current high score alongside the player's score, providing immediate context for their progress.
4. **Inclusive Achievements**: Previously, the "NEW BEST!" indicator and final congratulations were only shown if the player already had a non-zero high score. This change ensures that even first-time players feel a sense of accomplishment upon completing their first session.

All changes were verified with local builds, automated UX checks, and manual inspections of the terminal output.

---
*PR created automatically by Jules for task [2224357383521055628](https://jules.google.com/task/2224357383521055628) started by @aidasofialily-cmd*