### PR TITLE
🎨 Palette: Improve CLI line rendering

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2024-05-23 - Robust CLI Line Clearing
+**Learning:** When updating dynamic terminal lines using `\r` (carriage return), simply hardcoding padding spaces to overwrite previous content is fragile and leads to trailing text artifacts when the new content is shorter (e.g., toggling from a longer "NORMAL MODE" string to a shorter "HARD MODE" string).
+**Action:** Always use the ANSI "Erase in Line" escape sequence (`\033[K`) immediately after a carriage return (`\r`) in CLI applications to guarantee a cleanly erased line before writing new content, rather than relying on manual space padding.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/
+venv

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 Palette: Improve CLI line rendering

💡 What: Replaced hardcoded space padding with the ANSI "Erase in Line" escape sequence (`\033[K`) after carriage returns.
🎯 Why: Prevents text trailing artifacts when dynamically updating terminal lines (e.g., toggling from "NORMAL MODE" to "HARD MODE"), resulting in a much cleaner rendering experience without relying on fragile hardcoded spaces.
♿ Accessibility: Ensures consistent visual presentation without leftover text artifacts for users relying on visual updates.

---
*PR created automatically by Jules for task [15803187679036011965](https://jules.google.com/task/15803187679036011965) started by @EiJackGH*