### PR TITLE
🎨 Palette: Use ANSI Erase in Line for cleaner dynamic updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-24 - Clearing dynamic CLI lines cleanly
+**Learning:** When creating terminal applications that update dynamic lines in place (using `\r`), using hardcoded padding spaces to clear trailing text artifacts is fragile and can lead to visual bugs if the new string is shorter than expected. The ANSI escape sequence `\033[K` (Erase in Line) provides a clean, native way to clear from the cursor to the end of the line.
+**Action:** To prevent trailing text artifacts in CLI applications when updating dynamic terminal lines via `\r`, always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return instead of hardcoding padding spaces.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced manual space padding with the ANSI escape sequence `\033[K` (Erase in Line) when updating dynamic UI elements via carriage return (`\r`) in `src/main.cpp`.
🎯 **Why:** To prevent visual bugs (trailing artifacts) where a new dynamic string might be shorter than the previous one, ensuring a clean and consistent CLI interface redraw without relying on fragile hardcoded string lengths.
📸 **Before/After:** No visual change under normal circumstances, but fixes a subtle visual bug if the line ever shortens.
♿ **Accessibility:** N/A (Console rendering improvement)

---
*PR created automatically by Jules for task [15741563493922325819](https://jules.google.com/task/15741563493922325819) started by @EiJackGH*