### PR TITLE
🎨 Palette: [UX improvement] Enhance game start and real-time HUD

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,11 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2024-06-18 - Inclusive Achievement Feedback in CLI
+**Learning:** Checking for `initialHighscore > 0` before showing "NEW BEST!" or congratulations messages excludes first-time players from the positive feedback loop. Inclusive UX should celebrate the first record (e.g., first point scored) just as much as subsequent ones.
+**Action:** Always use `score > initialHighscore` instead of requiring `initialHighscore > 0` to trigger achievement feedback.
+
+## 2024-06-18 - Robust Line Clearing in CLI
+**Learning:** Using trailing spaces to "clear" the remainder of a line in terminal applications is fragile and can lead to visual artifacts if the new string is significantly shorter than the previous one. The ANSI escape sequence `\033[K` (Erase in Line) is the standard and most robust way to ensure a clean UI during in-place updates.
+**Action:** Use `\033[K` when performing carriage-return (`\r`) based UI updates to ensure the line is fully cleared.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ int main() {
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
-    std::cout << "Press any key to start... " << std::flush;
+    std::cout << "Press " << CLR_CTRL << "any key" << CLR_RESET << " to start... " << std::flush;
     struct pollfd start_fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     if (poll(start_fds, 1, -1) > 0) {
         if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -124,7 +124,10 @@ int main() {
         if (poll(fds, 1, remaining) > 0) {
             if (read(STDIN_FILENO, &input, 1) <= 0 || input == 'q') break;
             if (input == 'h') hardMode = !hardMode;
-            else score++;
+            else {
+                score++;
+                if (score > highscore) highscore = score;
+            }
             updateUI = true;
         }
 
@@ -132,15 +135,16 @@ int main() {
         elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_tick).count();
         if (elapsed >= timeout_ms) {
             score++;
+            if (score > highscore) highscore = score;
             last_tick = now;
             updateUI = true;
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" : "")
+                      << "\033[K" << CLR_RESET << std::flush;
             updateUI = false;
         }
     }
@@ -151,8 +155,8 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
-        std::cout << "Congratulations! A new personal best!\n";
+    if (score > initialHighscore) {
+        std::cout << CLR_NORM << "Congratulations! A new personal best!\n" << CLR_RESET;
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What: The UX enhancement added
This PR implements several micro-UX improvements to the SPEED CLICKER game:
1.  **Enhanced Visual Hierarchy:** Highlights critical interaction keywords ("any key") and the countdown sequence with bold colors to guide player attention.
2.  **Real-time High Score Tracking:** The HUD now displays the current session record (`High: X`) alongside the score, providing immediate feedback on progress.
3.  **Inclusive Achievement Logic:** The "NEW BEST! 🥳" notification and final congratulations now trigger for first-time players (where initial high score is 0), ensuring a rewarding experience from the very first point.
4.  **Polished CLI Output:** Replaced fragile trailing-space line clearing with the robust ANSI `\033[K` (Erase in Line) sequence, preventing text artifacts during high-frequency updates.

### 🎯 Why: The user problem it solves
- Users lacked immediate feedback on how close they were to their high score during gameplay.
- First-time players were excluded from "NEW BEST!" celebrations, making the initial experience less engaging.
- Terminal output could occasionally leave trailing characters if a previous HUD line was longer than the current one.
- Critical instructions were not visually distinct from the rest of the text.

### ♿ Accessibility: Any a11y improvements made
- Improved readability of instructions by using semantic colors to highlight interactive elements.
- Ensured all volatile `\r` lines are reset with `CLR_RESET` to prevent color leakage to the user's terminal/screen reader.
- Maintained strict cursor management (hiding during game, restoring on exit) to reduce visual clutter and ensure terminal usability after the game ends.

---
*PR created automatically by Jules for task [8769413402183838912](https://jules.google.com/task/8769413402183838912) started by @aidasofialily-cmd*