### PR TITLE
🎨 Palette: Improve dynamic terminal clearing with ANSI escape sequence

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-25 - Clearing Dynamic CLI Output
+**Learning:** Hardcoding trailing spaces to erase previous terminal output when using carriage returns (`\r`) is unreliable and can lead to trailing text artifacts if the previous line was longer than the padding.
+**Action:** Use the ANSI "Erase in Line" escape sequence (`\033[K`) immediately after a carriage return (`\r`) in dynamic terminal updates to guarantee a clean render without manual padding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced hardcoded space padding strings with the ANSI Erase in Line escape sequence (`\033[K`) after carriage returns (`\r`) in dynamic terminal output updates.
🎯 **Why:** To eliminate visual trailing text artifacts during rapid dynamic terminal string updates if the previous line text is longer than the new padding. This ensures a clean refresh on every render frame for elements like the countdown timer and active score without needing manual padding calculations.
♿ **Accessibility:** N/A (Visual polish).
📝 **Journaled:** Logged the UX insight regarding standardizing on ANSI clear sequences rather than padding logic for CLI terminal text erasure.

---
*PR created automatically by Jules for task [9189652303841362409](https://jules.google.com/task/9189652303841362409) started by @EiJackGH*