### PR TITLE
🎨 Palette: Prevent trailing text artifacts during dynamic terminal updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-05-24 - Preventing Trailing Artifacts in CLI Dynamic Lines
+**Learning:** When dynamically updating terminal lines using carriage returns (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle. It can lead to trailing artifacts if the new text string happens to be shorter than the previously printed string minus the padding.
+**Action:** To prevent trailing text artifacts in CLI applications when updating dynamic terminal lines via `\r`, always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return instead of hardcoding padding spaces.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Added the ANSI escape sequence `\033[K` (Erase in Line) immediately following carriage returns (`\r`) in terminal output strings, and removed the previously hardcoded padding spaces.

🎯 **Why:** When dynamically updating a single line in a CLI (e.g., scores, timers), using a carriage return simply moves the cursor back to the start of the line. If the new string is shorter than the previously rendered string, the end of the old string will still be visible as a "trailing artifact." Previously, the code relied on hardcoding multiple spaces to artificially pad strings and overwrite this leftover text, which is brittle. Using `\033[K` robustly clears the line from the cursor to the end, preventing any artifacts regardless of string length.

📸 **Before/After:**
*Before:* `std::cout << "\rGO!             \n" << std::flush;`
*After:* `std::cout << "\r\033[KGO!\n" << std::flush;`

♿ **Accessibility:** This UX polish ensures terminal readers and visual users don't encounter confusing or garbled text during rapid UI updates. Additionally, a new learning entry was recorded in `.Jules/palette.md` to establish this standard for future interactions.

---
*PR created automatically by Jules for task [4127214504803152438](https://jules.google.com/task/4127214504803152438) started by @EiJackGH*