### PR TITLE
🎨 Palette: Inclusive achievement feedback for first-time players

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-26 - Inclusive Achievement Feedback
+**Learning:** UX patterns for achievement celebrations (e.g., 'NEW BEST! 🥳') should be inclusive of first-time players. Requiring a pre-existing high score (`initialHighscore > 0`) to trigger these rewards creates a "cold start" problem where a user's initial success goes unacknowledged.
+**Action:** Ensure achievement logic triggers as soon as the current score exceeds the previous record, even if that record is zero, to provide immediate positive reinforcement.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,7 +139,7 @@ int main() {
         if (updateUI) {
             std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
                       << "           " << std::flush;
             updateUI = false;
         }
@@ -151,7 +151,7 @@ int main() {
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
-    if (score > initialHighscore && initialHighscore > 0) {
+    if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }
     std::cout << "Thanks for playing!\n";


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Removed the `initialHighscore > 0` conditional check for achievement-related UI elements in `src/main.cpp`.

### 🎯 Why: The user problem it solves
Previously, new players would not receive any "NEW BEST!" feedback or congratulations during or after their first game, because the logic required a pre-existing high score. This created a "cold start" experience where the user's initial progress went unacknowledged.

### ♿ Accessibility & Inclusivity
Makes the achievement system inclusive of first-time players, ensuring that everyone receives immediate positive reinforcement for their performance.

### 🧪 Verification
Verified the change using a custom Python script with `pty.fork()` to simulate a clean start (no `highscore.txt`) and confirm the presence of "NEW BEST! 🥳" and the final congratulation message in the terminal output. Verified that cursor hide/show behavior remains intact via `verify_ux.py`.

---
*PR created automatically by Jules for task [14605197382710782397](https://jules.google.com/task/14605197382710782397) started by @aidasofialily-cmd*