### PR TITLE
🎨 Palette: [UX improvement] Fix trailing text artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-02 - Hiding the Cursor in CLI Games
 **Learning:** In terminal applications that require rapid visual updates or where user input doesn't involve typing text, an actively blinking cursor can be a visual distraction. Hiding it during interaction (`\033[?25l`) and rigorously ensuring it is restored (`\033[?25h`) on exit—including signal interrupts—significantly improves the aesthetic and focus.
 **Action:** Always hide the cursor for interactive CLI games and explicitly restore it across all exit paths, including async-signal-safe signal handlers.
+
+## 2026-03-27 - ANSI Erase in Line for Cleaner CLI Outputs
+**Learning:** When updating a terminal line dynamically (e.g. using ''), relying on hardcoded padding spaces to overwrite old text is fragile and can leave trailing artifacts if the new string is shorter than the old one. The ANSI escape sequence '[K' (Erase in Line) provides a clean, robust way to instantly clear the line from the cursor to the end.
+**Action:** Always use '[K' immediately after a carriage return ('') when overwriting dynamic lines in CLI applications to prevent trailing text artifacts.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << i << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << i << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\rGO!             \n" << std::flush;
+    std::cout << "\r\033[KGO!\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -137,10 +137,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore && initialHighscore > 0 ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Replaced hardcoded padding spaces with the ANSI Erase in Line sequence (`\033[K`) after dynamic carriage return (`\r`) line updates.
🎯 Why: Prevents brittle trailing text artifacts when a new CLI string is shorter than the old one, resulting in a cleaner and more robust interface layout.
📸 Before/After: N/A
♿ Accessibility: Improves visual clarity of dynamic CLI elements.

---
*PR created automatically by Jules for task [4341122783861923084](https://jules.google.com/task/4341122783861923084) started by @EiJackGH*