### PR TITLE
🎨 Palette: Polish CLI UX with score formatting and clean UI updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-03-29 - Robust CLI Line Clearing & Score Readability
+**Learning:** Manual space padding in CLI HUDs is brittle and often leaves "ghost" characters when strings shorten. Using the ANSI "Erase in Line" sequence (`\033[K`) ensures a clean UI regardless of string length. Additionally, providing thousands separators in clicker games significantly reduces cognitive load as scores escalate.
+**Action:** Always prefer `\033[K` over manual space padding for in-place line updates, and implement a `formatWithCommas` helper for all numeric score displays.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,6 @@
 #include <cstdlib>
 
 // Color and formatting macros for terminal output
-#define RESET     "\033[0m"
 #define RED       "\033[31m"
 #define GREEN     "\033[32m"
 #define YELLOW    "\033[33m"
@@ -50,6 +49,15 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    for (int i = n - 3; i > 0; i -= 3) {
+        s.insert(i, ",");
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +85,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -108,7 +116,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!\033[K" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +149,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +162,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces several micro-UX enhancements to the Speed Clicker terminal game to improve readability and visual polish.

### 💡 What: The UX enhancement added
- **Score Readability:** Added a `formatWithCommas` helper to provide thousands separators for all score displays (Personal Best, live HUD, and Final Score).
- **Clean UI Updates:** Replaced manual space padding in the "GO!" prompt and gameplay HUD with the ANSI "Erase in Line" (`\033[K`) sequence, ensuring a clean terminal state regardless of string length.
- **Achievement Context:** Modified the post-game screen to display the previous personal best when a new record is set, providing meaningful context for the user's success.
- **Macro Consolidation:** Removed the redundant `RESET` macro in favor of the standardized `CLR_RESET`.

### 🎯 Why: The user problem it solves
- Large numeric scores were difficult to parse at a glance.
- Manual padding can be brittle and leave trailing characters if strings shorten (though unlikely here, it's a best-practice for CLI tools).
- Setting a new best felt slightly isolated without knowing the previous target that was surpassed.

### ♿ Accessibility: Any a11y improvements made
- Improved cognitive accessibility by making large numbers easier to read.
- Used standardized ANSI sequences for terminal control, ensuring better compatibility with various terminal emulators.

Verified with `make` and `verify_ux.py`.

---
*PR created automatically by Jules for task [17684848214439175307](https://jules.google.com/task/17684848214439175307) started by @aidasofialily-cmd*