### PR TITLE
🎨 Palette: Improve score readability and game-over context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-03-30 - Enhanced Feedback & Readability in CLI
+**Learning:** Large numbers in CLI are hard to read without thousands separators. Using \033[K (Erase in Line) is superior to space-padding for clean UI updates. Providing the previous record for comparison on the game-over screen enhances the user's sense of achievement.
+**Action:** Use formatWithCommas for all large numeric displays and \033[K for in-place line updates. Always show 'before and after' context for achievements.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,16 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long value) {
+    std::string res = std::to_string(value);
+    int pos = res.length() - 3;
+    while (pos > 0) {
+        res.insert(pos, ",");
+        pos -= 3;
+    }
+    return res;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +87,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +151,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << CLR_RESET << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +164,12 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
+        if (initialHighscore > 0) {
+            std::cout << "You beat your previous best of " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << "!\n";
+        }
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces small but impactful micro-UX improvements to the SPEED CLICKER game:

1.  **Readability**: Scores now include thousands separators (e.g., `1,234`) instead of raw numbers, making them much easier to read at a glance.
2.  **Visual Polish**: The live score line now uses the ANSI `\033[K` (Erase in Line) sequence. This ensures that when the score or status message changes length, no leftover characters from the previous update remain on the screen, providing a much cleaner "tactile" feel.
3.  **Achievement Context**: When a player breaks their personal record, the game-over screen now explicitly shows their previous best score (e.g., "You beat your previous best of 10!"). This provides meaningful context and enhances the user's sense of accomplishment.

♿ **Accessibility**: Improved numeric readability is a key accessibility win for users with cognitive or visual impairments. The use of standard ANSI clearing sequences improves compatibility across different terminal emulators.

---
*PR created automatically by Jules for task [3421603949046176275](https://jules.google.com/task/3421603949046176275) started by @aidasofialily-cmd*