### PR TITLE
🎨 Palette: Use ANSI Erase in Line (`\033[K`) to prevent text artifacts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-03-31 - ANSI Erase in Line
+**Learning:** Using '' to overwrite previous lines in a CLI can leave trailing text artifacts if the new line is shorter than the old one. Relying on hardcoded padding spaces is brittle.
+**Action:** Use the ANSI escape sequence '[K' immediately after the carriage return ('') to securely and cleanly clear dynamic lines to the end of the line.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/
+
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "..." << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Replaced hardcoded padding spaces with the ANSI Erase in Line escape sequence (`\033[K`) after carriage returns in the UI output.
🎯 Why: When dynamic lines (like the "Starting in 3..." or "Score: 100") update, replacing a longer line with a shorter line can leave trailing characters behind. Using `\033[K` immediately clears the line to the right of the cursor, cleanly overwriting previous text without needing to guess how many padding spaces to add.
📸 Before/After: Visual changes only noticeable during transitions where text shrinks in length.
♿ Accessibility: N/A - but improves visual clarity for all sighted users by removing visual artifacts.

---
*PR created automatically by Jules for task [9419785241340369082](https://jules.google.com/task/9419785241340369082) started by @EiJackGH*