### PR TITLE
🎨 Palette: Cleanly erase dynamic terminal lines using ANSI escape sequence

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-04-01 - [Use ANSI Erase in Line instead of padding spaces]
+**Learning:** When using carriage returns (``) to update dynamic terminal lines, using hardcoded padding spaces to clear previous output is unreliable and can leave trailing artifacts, especially if the new output string is shorter than the previous one.
+**Action:** Always use the Erase in Line (`[K`) ANSI escape sequence immediately after the carriage return to cleanly erase the terminal line before writing new content.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced hardcoded padding spaces with the ANSI "Erase in Line" escape sequence (`\033[K`) to dynamically clear terminal lines.
🎯 **Why:** To prevent visual artifacts (trailing text) when updating dynamic output like the HUD or the countdown timer. When a shorter string replaced a longer string (e.g. from `Score: 100` to a shorter generic line if that were to happen, or just clearing "Starting in 3..."), the hardcoded spaces were unreliable and could leave trailing characters on the line. Using `\033[K` guarantees the remainder of the line is cleanly erased before drawing new content.
♿ **Accessibility/UX:** Improves the overall visual clarity and polish of the terminal interface, ensuring real-time updates are crisp and artifact-free. Added a journal entry detailing this best practice.

---
*PR created automatically by Jules for task [14705242957524992324](https://jules.google.com/task/14705242957524992324) started by @EiJackGH*