### PR TITLE
🎨 Palette: Improve line clearing UX with ANSI erase in line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-04-02 - UI Artifact Cleanup in Dynamic CLI Lines
+**Learning:** Using manual string padding (e.g., spaces) to overwrite previous terminal output lengths can lead to messy, hard-to-maintain code, and visual artifacts if lines change length unpredictably.
+**Action:** Use the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return (`\r`) to ensure a clean, smooth UX for dynamically updating single-line CLI output without trailing text.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "") << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced manual space padding with the `\033[K` (Erase in Line) ANSI escape sequence for dynamic CLI outputs.
🎯 **Why:** To prevent visual trailing text artifacts when line lengths change unpredictably during dynamic terminal updates. Using `\033[K` immediately after a carriage return ensures the interface remains clean and artifact-free.
📸 **Before/After:** No visual UI element change, but prevents trailing artifacts.
♿ **Accessibility:** Improves readability by keeping the UI clean and predictable.

---
*PR created automatically by Jules for task [13254324751434602542](https://jules.google.com/task/13254324751434602542) started by @EiJackGH*