### PR TITLE
🎨 Palette: Polish score display and HUD in CLI game

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-04-02 - Polish and Context in CLI Games
+**Learning:** In terminal games with escalating scores, thousands separators are essential for readability. Furthermore, using ANSI escape codes like `\033[K` (Erase in Line) is superior to trailing spaces for clearing lines, as it handles dynamic string lengths (like "NEW BEST!" appearing) without visual artifacts. Providing historical context (e.g., "Previous Best") on achievement screens reinforces the user's progress.
+**Action:** Implement numeric formatting for large values and use specific ANSI line-clearing codes in CLI UIs. Always provide context for new records to enhance the sense of achievement.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,15 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long value) {
+    std::string res = std::to_string(value);
+    int n = res.length();
+    for (int i = n - 3; i > 0; i -= 3) {
+        res.insert(i, ",");
+    }
+    return res;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +86,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +103,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... \033[K" << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +117,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!\033[K" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +150,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +163,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces a series of micro-UX improvements to the "Speed Clicker" CLI game to enhance readability, visual stability, and player feedback.

### 💡 What: The UX enhancement added
1.  **Numeric Formatting:** Large scores are now formatted with thousands separators (e.g., `1,234` instead of `1234`), making them much easier to read at a glance.
2.  **Visual Polish:** HUD updates now use the ANSI `\033[K` escape code to clear the line to the end. This is a more robust method than trailing spaces, ensuring that no visual artifacts are left behind when the string length changes dynamically (e.g., when "NEW BEST!" toggles).
3.  **Contextual Feedback:** When a player breaks their record, the game-over screen now displays their previous personal best, providing immediate context for their achievement.

### 🎯 Why: The user problem it solves
- **Readability:** As scores escalate, large integers become difficult to parse quickly.
- **Visual Stability:** Hardcoded spaces for clearing lines are prone to error if the HUD text expands beyond the anticipated width. `\033[K` is the industry-standard way to handle this in terminal UIs.
- **Player Engagement:** Knowing *how much* you beat your previous record by adds a layer of satisfaction to the win.

### ♿ Accessibility: Any a11y improvements made
- Improved the visual hierarchy of the HUD by ensuring clean redraws, reducing flicker/artifacts that can be distracting for some users.
- The more readable score format aids users with cognitive or visual impairments in parsing large numbers.

Verified with `make` and `verify_ux.py`.

---
*PR created automatically by Jules for task [982230307104450477](https://jules.google.com/task/982230307104450477) started by @aidasofialily-cmd*