### PR TITLE
🎨 Palette: Clean Terminal Updates with \033[K

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-23 - Clean Terminal Updates
+**Learning:** In terminal applications, using hardcoded padding spaces to overwrite old text during dynamic updates (e.g., using `\r`) can lead to visual artifacts if the new text is shorter than the old text and the padding is insufficient, or it can cause wrap-around issues if it's too long.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return (`\r`) to ensure a clean slate for the new line of text, removing the need for manual spacing and improving reliability.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "..." << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "") << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** The UX enhancement added is the use of the ANSI escape sequence `\033[K` (Erase in Line) to overwrite leftover text in the terminal during dynamic updates instead of relying on manually padded spaces.

🎯 **Why:** The user problem it solves is visual artifacts. When a new dynamic text string is shorter than the text previously printed on the line, trailing characters will visually linger unless explicitly erased or padded with spaces. Using `\033[K` ensures the line is cleanly erased from the cursor onward, making updates more robust without having to guess string length and padding.

📸 **Before/After:** No major visible change, but prevents visual glitches without requiring manual padding.

♿ **Accessibility/DX:** Improves Developer Experience (DX) for anyone modifying the output strings by removing the need to manage padding spaces manually. Added a journal entry to `.Jules/palette.md` to document this CLI pattern.

---
*PR created automatically by Jules for task [12886775252101960450](https://jules.google.com/task/12886775252101960450) started by @EiJackGH*