### PR TITLE
🎨 Palette: Enhance CLI UX with score formatting and visual polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Clean Line Updates in CLI
+**Learning:** Using trailing spaces to "clear" old text in carriage-returned (`\r`) lines is fragile and often leaves "ghost" characters if the new string is shorter than the previous one. The ANSI escape sequence `\033[K` (Erase in Line) is the robust way to ensure a clean UI by clearing everything from the cursor to the end of the line.
+**Action:** Always append `\033[K` to the end of lines that use `\r` for in-place updates in terminal applications.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,16 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long n) {
+    std::string s = std::to_string(n);
+    int insertPosition = s.length() - 3;
+    while (insertPosition > 0) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +87,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +104,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... \033[K" << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +118,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\033[K\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +151,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +165,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
Implemented several micro-UX improvements to the SPEED CLICKER terminal game:
- Added a `formatWithCommas` helper to provide thousands separators for scores (e.g., 1,000 instead of 1000), significantly improving readability.
- Replaced manual space padding with the ANSI `\033[K` (Erase in Line) escape sequence for cleaner in-place terminal updates.
- Enhanced the live HUD with colorized labels and achievement feedback.
- Polished the splash screen and countdown visuals.

These changes make the CLI interface feel more professional and responsive.

---
*PR created automatically by Jules for task [16578675290318151996](https://jules.google.com/task/16578675290318151996) started by @aidasofialily-cmd*