### PR TITLE
🎨 Palette: Prevent trailing text artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Avoiding Trailing Text Artifacts in CLI
+**Learning:** When using carriage returns (``) to update dynamic terminal lines, the new string might be shorter than the previous one, leaving trailing characters (artifacts) visible. Hardcoded padding spaces are error-prone and brittle.
+**Action:** Always use the ANSI 'Erase in Line' escape sequence (`[K`) immediately after a carriage return to clear the line before printing the new content, ensuring a clean update without manual padding.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLEAR_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" CLEAR_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" CLEAR_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" CLEAR_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "") << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
### 💡 What
Migrated dynamic terminal line updates (countdowns, score displays) to use the standard ANSI Erase in Line escape sequence (`\033[K`) immediately following carriage returns (`\r`). 

### 🎯 Why
When updating a CLI line in place using `\r`, if the new string is shorter than the previous one, the remaining characters of the old string "bleed through" as artifacts. Previously, the code mitigated this by aggressively appending hardcoded padding spaces to the end of every update. This is brittle and error-prone. Using `\033[K` immediately after the `\r` guarantees a clean slate for the new string to be drawn without manual padding.

### ♿ Accessibility / UX
Ensures a visually clean, artifact-free output during high-frequency CLI UI updates, improving the "tactile" and polished feel of the application.

*Also appended this learning to `.Jules/palette.md`.*

---
*PR created automatically by Jules for task [16234612380724654085](https://jules.google.com/task/16234612380724654085) started by @EiJackGH*