### PR TITLE
🎨 Palette: Improve score readability and HUD polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-11-14 - Visual Polish in Terminal HUDs
+**Learning:** In CLI applications where the UI updates in-place (e.g., using `\r`), simply overwriting with a new string can leave behind "ghost" characters if the new string is shorter than the previous one. While space-padding works, using the ANSI escape sequence `\033[K` (Erase in Line) is a cleaner, more robust way to ensure the remainder of the line is cleared. Additionally, formatting large numbers with thousands separators significantly improves readability as scores escalate.
+**Action:** Use `\033[K` for in-place terminal updates and implement a `formatWithCommas` utility for all large numeric displays.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,16 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string num_str = std::to_string(value);
+    int insertPosition = num_str.length() - 3;
+    while (insertPosition > 0) {
+        num_str.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return num_str;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +87,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -108,7 +118,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!\033[K" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +151,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +165,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best (Previous: " << formatWithCommas(initialHighscore) << ")!\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces several micro-UX enhancements to the Speed Clicker CLI to improve readability and visual polish:

1.  **Numeric Formatting**: Implemented a `formatWithCommas` helper to add thousands separators to all score displays. This makes large scores significantly easier to parse at a glance (e.g., "1,000,000" vs "1000000").
2.  **Cleaner HUD Updates**: Replaced the previous manual space-padding with the `\033[K` (Erase in Line) ANSI escape sequence. This ensures that when the score or HUD text length changes, no "ghost" characters are left behind from the previous frame.
3.  **Achievement Context**: Updated the game-over screen to show the previous personal best alongside the new record. This provides immediate, meaningful context for the player's achievement.
4.  **Journaling**: Documented these CLI-specific UX patterns in `.Jules/palette.md`.

All changes are focused on making the terminal interface feel more "high-fidelity" and responsive.

---
*PR created automatically by Jules for task [4148773146192350782](https://jules.google.com/task/4148773146192350782) started by @aidasofialily-cmd*