### PR TITLE
🎨 Palette: Use ANSI Erase in Line for clean dynamic text

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-05 - Clean Dynamic Terminal Lines in CLI
+**Learning:** When using carriage returns (`\r`) to create dynamic, single-line updates in a CLI (like a countdown or real-time score), relying on hardcoded padding spaces to overwrite previous, longer strings is brittle and hacky. It can lead to trailing text artifacts if the new text is shorter than expected.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return `\r` (e.g., `\r\033[K`) to cleanly clear the line before printing the new content, eliminating the need for padding spaces.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 Palette: Use ANSI Erase in Line for clean dynamic text

### 💡 What
Replaced brittle hardcoded padding spaces with the `\033[K` (Erase in Line) ANSI escape sequence after carriage returns (`\r`) in `src/main.cpp`.

### 🎯 Why
When using `\r` to update a single line in the terminal (like the countdown or the live score), if the new text is shorter than the old text, the remaining characters from the old text will still be visible unless explicitly overwritten or cleared. Previously, this was handled by appending an arbitrary number of spaces (e.g., `"GO!             "`). This is a hacky approach. Using `\033[K` cleanly and robustly clears the rest of the line from the cursor's current position, preventing trailing text artifacts.

### ♿ Accessibility
Improves the visual clarity and robustness of the terminal output.

---
*PR created automatically by Jules for task [6379589593499289330](https://jules.google.com/task/6379589593499289330) started by @EiJackGH*