### PR TITLE
🎨 Palette: CLI Score Formatting & UI Polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-01-25 - Readability and Polish in CLI Scoreboards
+**Learning:** As numeric values scale in fast-paced CLI games, readability suffers without thousands separators. Adding a simple comma-formatting helper significantly reduces cognitive load. Furthermore, using the ANSI "Erase in Line" sequence (`\033[K`) is superior to hardcoded space-padding for clearing volatile lines, as it adaptively handles varying text lengths and prevents visual artifacts.
+**Action:** Always implement thousands separators for large numeric displays and use `\033[K` for flicker-free, in-place terminal UI updates.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,16 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length() - 3;
+    while (n > 0) {
+        s.insert(n, ",");
+        n -= 3;
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,13 +87,13 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
-    std::cout << "Press any key to start... " << std::flush;
+    std::cout << "Press " << CLR_CTRL << "any key" << CLR_RESET << " to start... " << std::flush;
     struct pollfd start_fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     if (poll(start_fds, 1, -1) > 0) {
         if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
@@ -141,10 +151,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +164,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
I have implemented several micro-UX improvements to the SPEED CLICKER CLI game to enhance readability and polish. 

The primary change is the addition of a `formatWithCommas` helper function, which ensures that large scores are displayed with thousands separators (e.g., "1,234" instead of "1234"). This significantly improves readability as scores escalate. 

I also replaced hardcoded space padding in the live HUD with the ANSI escape sequence `\033[K` (Erase in Line), which ensures a clean, flicker-free UI regardless of the text length. 

Finally, I highlighted the "any key" instruction in the start prompt using the existing `CLR_CTRL` color macro to better guide the user's attention.

All changes were verified with `make` and the existing `verify_ux.py` script.

---
*PR created automatically by Jules for task [9770629412281978787](https://jules.google.com/task/9770629412281978787) started by @aidasofialily-cmd*