### PR TITLE
🎨 Palette: Clean Dynamic Output with \033[K

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-25 - Clean Dynamic Output in CLI
+**Learning:** When dynamically updating text in terminal applications (like progress bars, countdowns, or score displays), simply returning the cursor to the start of the line using a carriage return (`\r`) can leave "ghost" characters if the new string is shorter than the old one. Relying on padding spaces is brittle and hard to maintain. Using the ANSI "Erase in Line" escape sequence (`\033[K`) right after `\r` provides a robust, clean slate by clearing from the cursor position to the end of the line.
+**Action:** Always append `\033[K` immediately following `\r` when rewriting dynamic CLI lines to prevent text artifacts without needing hardcoded padding spaces.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "") << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced hardcoded space padding in dynamic `std::cout` updates with the ANSI "Erase in Line" escape sequence (`\033[K`) immediately following carriage returns (`\r`). Recorded this learning in `.Jules/palette.md`.
🎯 **Why:** Dynamically updating text in the terminal using `\r` can leave "ghost" characters if the new line is shorter. Hardcoding trailing spaces is a brittle, unmaintainable hack. `\033[K` provides a clean slate by clearing from the cursor position to the end of the line, creating a much more robust and visually consistent developer and user experience. Also ignored `venv/` globally for DX cleanliness.
📸 **Before/After:** No major UI layout changes, but eliminates potential trailing edge text bugs during gameplay.
♿ **Accessibility:** Makes terminal rendering and potential assistive device parsing of the terminal state much cleaner and less prone to "stuck" output.

---
*PR created automatically by Jules for task [17377034281091953670](https://jules.google.com/task/17377034281091953670) started by @EiJackGH*