### PR TITLE
🎨 Palette: Display previous personal best on game-over screen

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Contextual Achievement Feedback
+**Learning:** Providing historical context (like a previous personal best) alongside a new achievement on a game-over screen enhances the user's sense of progress and makes the reward feel more earned. In CLI environments where visual space is limited, this specific detail provides high impact for minimal code change.
+**Action:** Always look for opportunities to provide "Before/After" or "New vs. Old" context when celebrating user milestones or record-breaking events.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ int main() {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << initialHighscore << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What
This PR enhances the game-over screen of the SPEED CLICKER game by displaying the user's previous personal best when they achieve a new high score.

### 🎯 Why
In competitive or personal-record-based games, users find more delight in seeing the *scale* of their improvement rather than just a generic "new record" message. Providing this context makes the achievement feel more tangible and rewarding.

### ♿ Accessibility
The text remains plain and clear, ensuring it is easily readable by screen readers in a terminal environment. No additional complex ANSI sequences or colors were added to this specific message to maintain maximum compatibility.

---
*PR created automatically by Jules for task [4644765931202406853](https://jules.google.com/task/4644765931202406853) started by @aidasofialily-cmd*