### PR TITLE
🎨 Palette: Clean terminal line rendering with ANSI Erase to End of Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,4 +28,7 @@
 
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
-**Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-28 - Clean Terminal Rendering without Artifacts
+**Learning:** Relying on hardcoded padding spaces to clear previous text when rewriting lines with carriage returns (`\r`) can lead to visual artifacts or messy rendering, particularly on variable length strings. Using the ANSI escape sequence `\033[K` (Erase to end of line) guarantees the entire remainder of the line is cleanly erased.
+**Action:** Use `\033[K` immediately after `\r` instead of trailing spaces to clean dynamic terminal lines.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced hardcoded padding spaces with the `\033[K` ANSI escape sequence after carriage returns (`\r`) in terminal output strings in `src/main.cpp`. Added a journal entry about this finding.
🎯 **Why:** To prevent visual artifacts in the CLI. When rendering dynamic lines of text (like the score/high score display), using `\r` only returns the cursor to the beginning of the line without clearing the contents. If the new text is shorter than the previous text, leftover characters remain visible. Padding with hardcoded spaces is fragile; `\033[K` cleanly and efficiently guarantees the line is erased from the cursor forward, ensuring a polished interface.
♿ **Accessibility:** Provides a cleaner and less confusing visual experience for the user by eliminating stray characters and UI glitches.

---
*PR created automatically by Jules for task [3802564366012294575](https://jules.google.com/task/3802564366012294575) started by @EiJackGH*