### PR TITLE
🎨 Palette: Enhance terminal output with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Robust Terminal Line Clearing
+**Learning:** When creating dynamic CLI interfaces, relying on hardcoded padding spaces to clear previous text after a carriage return (`\r`) is fragile and often leads to trailing character artifacts if the new text is shorter than the old.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return (`\r`) to ensure the entire line is cleanly cleared before writing new content, providing a robust and artifact-free terminal UX.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "") << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Replaced hardcoded padding spaces with the ANSI `\033[K` (Erase in Line) escape sequence following carriage returns (`\r`) in the main game loop and countdown.

🎯 Why: Hardcoding space padding to clear dynamic terminal lines is fragile. If the new line string length is shorter than the previously printed line, trailing characters from the old line will "leak" and remain visible. Using `\033[K` instructs the terminal to robustly clear the rest of the line before writing new content, providing a cleaner, artifact-free experience.

📸 Before/After: Not applicable (prevents visual artifacts in dynamic terminal output).

♿ Accessibility: Provides a more stable and predictable interface without unexpected visual "noise" on the screen.

---
*PR created automatically by Jules for task [12300641143353141227](https://jules.google.com/task/12300641143353141227) started by @EiJackGH*