### PR TITLE
🎨 Palette: Improve score readability with thousands separators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-23 - Readability of Scalable Metrics in CLI
+**Learning:** In games where metrics (like scores) can scale rapidly, the lack of thousands separators makes it difficult for users to parse their progress at a glance. Providing immediate visual structure to large numbers reduces cognitive load and enhances the sense of achievement.
+**Action:** Always implement thousands separators for large numeric displays in CLI applications to maintain readability as values escalate.
+
+## 2024-05-23 - Contextual Achievement Feedback
+**Learning:** Simply stating "New Personal Best" is less impactful than providing the context of the previous record. Users appreciate seeing exactly how much they've improved, which reinforces the reward loop.
+**Action:** When announcing a new record or achievement, always include the previous milestone for context.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,16 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long n) {
+    std::string s = std::to_string(n);
+    int insertPosition = s.length() - 3;
+    while (insertPosition > (n < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +87,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,7 +151,7 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
                       << "           " << std::flush;
@@ -154,9 +164,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR implements a micro-UX improvement by adding thousands separators to all score displays in the SPEED CLICKER game. This improves readability as scores increase. It also adds context to the "New personal best" message by displaying the previous record.

---
*PR created automatically by Jules for task [1240665120474697299](https://jules.google.com/task/1240665120474697299) started by @aidasofialily-cmd*