### PR TITLE
🎨 Palette: Replace hardcoded terminal padding with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-04-10 - Use ANSI Erase in Line instead of padding spaces
+**Learning:** Relying on hardcoded padding spaces to clear previous terminal output when using carriage returns (``) is brittle and can leave trailing artifacts if the new text is shorter.
+**Action:** Use the ANSI sequence `[K` (Erase in Line) immediately after the carriage return for dynamic terminal lines.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
**💡 What:** Replaced hardcoded spaces with ANSI "Erase in Line" (`\033[K`) escape sequences for dynamic terminal UI updates. Also added `venv/` to `.gitignore`.
**🎯 Why:** Relying on space padding to overwrite text after a carriage return (`\r`) is brittle and can leave messy trailing artifacts if the new string is shorter than the old one. The ANSI sequence ensures robust clearing.
**📸 Before/After:** N/A (terminal visual change)
**♿ Accessibility:** Improves visual clarity by eliminating potential stray characters during fast screen updates.

---
*PR created automatically by Jules for task [14155554028460252545](https://jules.google.com/task/14155554028460252545) started by @EiJackGH*