### PR TITLE
🎨 Palette: Improve score readability and terminal UI polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-04-10 - Enhancing Numeric Readability and Terminal UI Polish
+**Learning:** Users find large numbers easier to parse with thousands separators in CLI environments. Additionally, using the ANSI escape sequence `\033[K` (Erase in Line) provides a more robust way to clear volatile terminal lines than padding with spaces, especially when the content length fluctuates.
+**Action:** Use a formatting helper for large numbers and `\033[K` for all `\r` based terminal updates to ensure a flicker-free and clean UI.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,17 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int insertPosition = n - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +152,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +165,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
### 🎨 Palette: Improve score readability and terminal UI polish

#### 💡 What
This enhancement introduces two key micro-UX improvements to the "Speed Clicker" CLI game:
1.  **Thousands Separators:** A new `formatWithCommas` helper function ensures that all score displays (Personal Best, live Score, and Final Score) use standard numeric formatting (e.g., `1,000` instead of `1000`).
2.  **Robust Line Clearing:** Replaced the fragile space-based padding (`"           "`) in the live HUD with the ANSI escape sequence `\033[K` (Erase in Line).

#### 🎯 Why
- **Readability:** As scores escalate quickly in a clicker game, long strings of digits become difficult to parse at a glance. Thousands separators provide immediate cognitive clarity.
- **Visual Polish:** Using `\033[K` ensures that the terminal line is perfectly cleared from the cursor to the end, preventing "ghost" characters or flicker when HUD elements change length (e.g., when toggling "NEW BEST! 🥳" or "HARD MODE").

#### ♿ Accessibility
- **Cognitive Load:** Eases the burden on users when reading and comparing large numeric values.
- **Predictable UI:** Standard terminal control sequences provide a more consistent experience across different terminal emulators.

#### 📸 Before/After
**Before:**
`Score: 1234 | High: 5678 [NORMAL MODE]`

**After:**
`Score: 1,234 | High: 5,678 [NORMAL MODE]` (with clean line clearing on state changes)

---
*PR created automatically by Jules for task [8395619920964877044](https://jules.google.com/task/8395619920964877044) started by @aidasofialily-cmd*