### PR TITLE
🎨 Palette: Improve score readability and achievement feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-12 - Improving Readability and UI Cleanliness in CLI
+**Learning:** For numeric-heavy CLI applications, thousand separators (e.g., `1,000,000` vs `1000000`) significantly reduce cognitive load. Additionally, using the ANSI "Erase in Line" (`\033[K`) sequence is superior to manual space padding for in-place line updates, as it handles varying text lengths more robustly and prevents visual "ghosting" of previous output.
+**Action:** Always implement a thousand-separator formatter for large numeric displays and use `\033[K` when updating terminal lines in-place.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,17 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int insertPosition = n - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +152,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +165,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What: The UX enhancement added
- Introduced a thousand-separator formatter for all score displays.
- Switched to using the ANSI `\033[K` sequence for cleaner in-place terminal updates.
- Enhanced the "New Personal Best" message to include the previous record for better context.

### 🎯 Why: The user problem it solves
- Large scores (e.g., 1000000) were difficult to read at a glance in a fast-paced clicker game.
- Manual space padding for UI updates can leave artifacts if the text length changes unexpectedly.
- Players didn't have immediate context on how much they beat their previous record by.

### ♿ Accessibility: Any a11y improvements made
- Improved readability of large numbers for all users.
- cleaner terminal updates reduce visual flicker and ghosting.

---
*PR created automatically by Jules for task [15681848255075481612](https://jules.google.com/task/15681848255075481612) started by @aidasofialily-cmd*