### PR TITLE
🎨 Palette: [UX improvement] Use ANSI Erase in Line instead of hardcoded padding

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-04-13 - Erase in Line
+**Learning:** To prevent trailing text artifacts in CLI applications when updating dynamic terminal lines via '\r', always use the ANSI escape sequence '\033[K' (Erase in Line) immediately after the carriage return instead of hardcoding padding spaces.
+**Action:** Use '\033[K' to erase the line after a carriage return.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLEAR_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" CLEAR_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" CLEAR_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" CLEAR_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: The UX enhancement added: Used the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return (`\r`) to dynamically clear the line instead of relying on hardcoded padding spaces.

🎯 Why: The user problem it solves: Hardcoded padding spaces are brittle and can lead to trailing text artifacts or visually unappealing whitespace selection in a terminal. Using the `\033[K` sequence ensures that the line is cleanly overwritten, preventing leftover characters from longer strings when rendering shorter strings dynamically (like score counts and statuses).

📸 Before/After: Visual changes apply under the hood, making terminal rendering cleaner by naturally clearing up characters rather than printing arbitrary spaces.

♿ Accessibility: The UX feels more consistent as the output visually maps accurately to its data layout without unpredictable artifacting.

---
*PR created automatically by Jules for task [9295768699379625375](https://jules.google.com/task/9295768699379625375) started by @EiJackGH*