### PR TITLE
🎨 Palette: Use ANSI Erase in Line for dynamic CLI updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-04-14 - Dynamic Line Erasing in CLI
+**Learning:** In terminal applications, using hardcoded spaces to pad and clear trailing characters when updating dynamic text (e.g. via carriage return '\r') can cause visual artifacts if the line length fluctuates. The ANSI escape sequence '\033[K' (Erase in Line) is a cleaner, more robust way to clear the remainder of the line.
+**Action:** Always use '\033[K' immediately after a carriage return instead of hardcoding padding spaces.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLEAR_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" << CLEAR_LINE << "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLEAR_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLEAR_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced hardcoded padding spaces with the ANSI escape sequence `\033[K` (Erase in Line) when dynamically updating the terminal output.

🎯 **Why:** In terminal applications, varying the length of an output line that overwrites the previous one (via `\r`) can leave trailing characters. Hardcoding spaces to overwrite them is brittle. Using the ANSI "Erase in Line" control sequence is robust, efficient, and guarantees a visually clean interface without artifacts.

♿ **Accessibility:** Improves visual clarity by preventing visual artifacts and text smearing for screen reader / magnifier users who rely on distinct text boundaries.

---
*PR created automatically by Jules for task [6375215757626852988](https://jules.google.com/task/6375215757626852988) started by @EiJackGH*