### PR TITLE
🎨 Palette: Prevent trailing text artifacts in CLI UI

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-04-15 - Prevent Trailing Text Artifacts in CLI
+**Learning:** When updating dynamic terminal lines via '', using hardcoded padding spaces is brittle and fails if the new string is shorter than the old one, leaving trailing artifacts.
+**Action:** Always use the ANSI escape sequence '[K' (Erase in Line) immediately after the carriage return instead of padding spaces to ensure a clean line refresh.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Replaced hardcoded padding spaces with the ANSI `\033[K` (Erase in Line) sequence when updating dynamic terminal lines via carriage return (`\r`) in the C++ game CLI.
🎯 Why: Using hardcoded spaces is brittle. If a new string is shorter than the previous string (e.g., when the score string length changes, or transitions occur), the padding spaces might not overwrite all characters, leaving trailing text artifacts. Using the `\033[K` escape sequence ensures the rest of the line is cleanly erased, creating a smoother and more robust terminal UI experience.
♿ Accessibility: The clearer, artifact-free text updates improve readability and reduce visual confusion.

---
*PR created automatically by Jules for task [9846248704782520994](https://jules.google.com/task/9846248704782520994) started by @EiJackGH*