### PR TITLE
🎨 Palette: Improve numeric readability and visual polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Clean UI Updates with Erase in Line
+**Learning:** In CLI applications that update lines in-place using carriage returns (`\r`), simply printing spaces to overwrite old content is brittle and can leave "ghost" characters if the new string is shorter than the previous one. Using the ANSI escape sequence `\033[K` (Erase in Line) provides a much cleaner and more reliable way to ensure the rest of the line is cleared.
+**Action:** Use `\033[K` instead of trailing spaces for all in-place UI updates in terminal applications.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include <cmath>
 
 // Color and formatting macros for terminal output
 #define RESET     "\033[0m"
@@ -30,6 +31,17 @@ void restore_terminal(int signum) {
     const char msg[] = "\033[0m\033[?25h\n\nGame interrupted. Terminal settings restored.\n";
     write(STDOUT_FILENO, msg, sizeof(msg) - 1);
     _exit(signum);
+}
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    int insertPosition = s.length() - 3;
+    while (insertPosition > 0) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    if (value < 0) s.insert(0, "-");
+    return s;
 }
 
 long long load_highscore() {
@@ -77,13 +89,13 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
-    std::cout << "Press any key to start... " << std::flush;
+    std::cout << "Press " << CLR_CTRL << "any key" << CLR_RESET << " to start... " << std::flush;
     struct pollfd start_fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     if (poll(start_fds, 1, -1) > 0) {
         if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << "\033[K\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +166,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces several micro-UX improvements to the Speed Clicker CLI game:

1.  **Readability:** Added a `formatWithCommas` helper to format scores (e.g., "1,234,567"). This makes progress easier to track as scores escalate.
2.  **Visual Polish:** Replaced brittle manual trailing spaces with the `\033[K` (Erase in Line) escape sequence for cleaner HUD and "GO!" message updates.
3.  **Discoverability:** Highlighted the "any key" interaction in the start prompt using the `CLR_CTRL` (Bold Yellow) color macro.
4.  **Achievement Context:** When a player sets a new record, the game now displays their previous personal best on the final screen, providing meaningful context for their achievement.
5.  **Delight:** Colorized the "NEW BEST! 🥳" real-time indicator to make the milestone feel more celebratory.

All changes are localized to `src/main.cpp` and maintain the existing terminal settings and signal safety. verified with `verify_ux.py` and manual logic tests.

---
*PR created automatically by Jules for task [10645592733879107262](https://jules.google.com/task/10645592733879107262) started by @aidasofialily-cmd*