### PR TITLE
🎨 Palette: Add thousands separators and polish HUD rendering

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-04-16 - Thousands Separators and HUD Polish in CLI
+**Learning:** For terminal-based games with escalating scores, thousands separators are essential for quick readability (accessibility). Additionally, using the `\033[K` (Erase in Line) ANSI sequence is more robust than manual whitespace padding for clearing in-place HUD updates, especially when formatted string lengths fluctuate.
+**Action:** Implement a `formatWithCommas` helper for all numeric displays and use `\033[K` for volatile terminal line updates.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,18 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int start = (value < 0) ? 1 : 0;
+    int pos = n - 3;
+    while (pos > start) {
+        s.insert(pos, ",");
+        pos -= 3;
+    }
+    return s;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +153,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << "\033[K" << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +166,12 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET << "\n";
+        if (initialHighscore > 0) {
+            std::cout << "(Previous personal best: " << formatWithCommas(initialHighscore) << ")\n";
+        }
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 🎨 Palette: Thousands Separators and HUD Polish

This PR adds small touches of delight and accessibility to the Speed Clicker game:

#### 💡 What:
- **Thousands Separators:** Added a `formatWithCommas` helper to format scores (e.g., `1,000` instead of `1000`).
- **HUD Polish:** Replaced manual trailing spaces in the HUD update line with the `\033[K` (Erase in Line) ANSI escape sequence.
- **Achievement Feedback:** Enhanced the "New Personal Best" message with color (`CLR_NORM`) and added context by displaying the previous personal best.

#### 🎯 Why:
- Large numbers are difficult to read at a glance in a fast-paced game; separators improve readability and accessibility.
- Manual padding in the HUD can lead to visual artifacts if the score or mode labels change length significantly; `\033[K` ensures a clean redraw.
- Providing context for a new record (the previous score) enhances the user's sense of achievement.

#### ♿ Accessibility:
- Improved readability of large numeric values for all users.
- Consistent color usage for success feedback.

---
*PR created automatically by Jules for task [5079295599851121323](https://jules.google.com/task/5079295599851121323) started by @aidasofialily-cmd*