### PR TITLE
🎨 Palette: Prevent Trailing Text Artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-20 - Prevent Trailing Text Artifacts in Dynamic CLI Output
+**Learning:** When using '' to dynamically update a terminal line, hardcoding trailing padding spaces is fragile and leaves artifacts if the new string is shorter than the old one. Always use the ANSI 'Erase in Line' sequence '[K' immediately after the carriage return.
+**Action:** Replaced trailing padding spaces with '[K' in src/main.cpp.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
### 💡 What
This PR updates the C++ CLI application to use the ANSI "Erase in Line" escape sequence (`\033[K`) instead of hardcoded padding spaces when dynamically updating terminal lines.

### 🎯 Why
When outputting dynamic, changing string lengths via carriage return (`\r`) in terminal applications, hardcoded spaces are brittle and can easily lead to trailing text artifacts if the new text is shorter than the old text (or if the padding isn't long enough). By explicitly clearing the line from the cursor position onward using `\033[K`, we ensure that the UI renders cleanly regardless of text length changes, improving the overall polish and accessibility of the terminal interface.

### ♿ Accessibility
This change improves visual clarity and prevents confusing text artifacts for terminal users relying on visual interfaces.

### ✅ Verification
* Compiled code successfully via `make`.
* Validated no trailing artifacts locally.
* Simulated TTY interactions successfully via `verify_ux.py` tests.
* Tested legacy bits via `test_bitcoin.py`.

---
*PR created automatically by Jules for task [5345167429889916625](https://jules.google.com/task/5345167429889916625) started by @EiJackGH*