### PR TITLE
🎨 Palette: UX improvements for Speed Clicker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-05-24 - Robust CLI UI Updates with Erase in Line
+**Learning:** In terminal applications that update the same line using carriage returns (\r), simply overwriting with new text can leave "ghost" characters if the new line is shorter than the previous one. Using the ANSI escape sequence \033[K (Erase in Line) after the new text ensures the remainder of the line is cleared, providing a much cleaner and more professional UI experience.
+**Action:** Always append an "Erase in Line" sequence (like a CLR_EOL macro) to the end of volatile terminal output lines that use \r.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -30,6 +31,18 @@ void restore_terminal(int signum) {
     const char msg[] = "\033[0m\033[?25h\n\nGame interrupted. Terminal settings restored.\n";
     write(STDOUT_FILENO, msg, sizeof(msg) - 1);
     _exit(signum);
+}
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int limit = (value < 0) ? 1 : 0;
+    int pos = n - 3;
+    while (pos > limit) {
+        s.insert(pos, ",");
+        pos -= 3;
+    }
+    return s;
 }
 
 long long load_highscore() {
@@ -77,13 +90,13 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
-    std::cout << "Press any key to start... " << std::flush;
+    std::cout << "Press " << CLR_CTRL << "any key" << CLR_RESET << " to start... " << std::flush;
     struct pollfd start_fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     if (poll(start_fds, 1, -1) > 0) {
         if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
@@ -141,10 +154,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +168,10 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET
+                  << " (Previous: " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility enhancements to the Speed Clicker terminal game:

- **Score Readability**: Scores now feature thousands separators (e.g., 1,234 instead of 1234) using a new `formatWithCommas` helper.
- **Visual Hierarchy**: Control instructions now highlight interaction keys (e.g., [Any key]) in bold yellow for better scannability.
- **UI Stability**: Implemented the `CLR_EOL` (\033[K) macro to ensure in-place terminal updates are clean and free of "ghost" characters from previous longer lines.
- **Feedback & Delight**:
    - The live HUD now uses consistent bold cyan for both Score and High labels/values.
    - The "NEW BEST! 🥳" indicator is now colorized in bold green.
    - The game-over screen provides contextual feedback by showing the previous personal best alongside the new record.

All changes are under 50 lines and maintain existing design patterns while improving the overall tactile feel and accessibility of the CLI interface.

---
*PR created automatically by Jules for task [13097170865778743972](https://jules.google.com/task/13097170865778743972) started by @aidasofialily-cmd*