### PR TITLE
🎨 Palette: Improve score readability and visual polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Numeric Readability and Visual Polish in CLI
+**Learning:** As numeric values escalate in games, raw integers become difficult to parse at a glance. Implementing thousands-separator formatting (e.g., `1,000,000`) significantly reduces cognitive load. Additionally, in terminal UIs that use carriage returns for in-place updates, explicit color resets (`CLR_RESET`) are crucial after every formatted segment to prevent color bleed into subsequent padding or UI elements.
+**Action:** Always format large numeric outputs with separators and rigorously apply color resets in volatile terminal HUD lines.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,16 @@ void restore_terminal(int signum) {
     _exit(signum);
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int start = (value < 0) ? 1 : 0;
+    for (int i = n - 3; i > start; i -= 3) {
+        s.insert(i, ",");
+    }
+    return s;
+}
+
 long long load_highscore() {
     long long highscore = 0;
     std::ifstream file("highscore.txt");
@@ -77,7 +87,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,9 +151,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
                       << "           " << std::flush;
             updateUI = false;
         }
@@ -154,9 +164,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET << " (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR implements several micro-UX improvements to the SPEED CLICKER game:

1. **Numeric Readability**: Added a `formatWithCommas` helper function to format scores with thousands separators (e.g., `1,234` instead of `1234`). This makes it much easier to read high scores at a glance.
2. **Visual Polish**: Fixed an issue where terminal colors could bleed in the HUD. Now, colors are explicitly reset after the mode indicator and the "NEW BEST!" message.
3. **Achievement Context**: Updated the game-over screen to display the previous personal best when a new record is achieved, providing immediate context for the player's success.
4. **Enhanced Feedback**: Colorized achievement messages using the existing `CLR_NORM` (Bold Green) to make them stand out.

These changes are well within the 50-line limit and significantly improve the tactile feel and accessibility of the game.

---
*PR created automatically by Jules for task [2219485194086769551](https://jules.google.com/task/2219485194086769551) started by @aidasofialily-cmd*