### PR TITLE
🎨 Palette: Improve score readability and achievement feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-04-20 - Contextual Achievement Feedback
+**Learning:** Simply telling a user they achieved a "new personal best" is good, but providing the previous record as context makes the achievement feel more tangible and rewarding. It quantifies the improvement and reinforces the sense of progress.
+**Action:** When announcing a new record or milestone, always display the previous best value alongside the new one to provide immediate context for the user's growth.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string res = std::to_string(value);
+    int start = (value < 0) ? 1 : 0;
+    int insertPosition = res.length() - 3;
+    while (insertPosition > start) {
+        res.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return res;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | "
+                      << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,13 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET;
+        if (initialHighscore > 0) {
+            std::cout << " (Previous: " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << ")";
+        }
+        std::cout << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What: The UX enhancement added
- Thousands-separator formatting for all score displays (Personal Best, live HUD, Final Score).
- Contextual achievement feedback on the game-over screen (showing the previous record).
- Professional terminal line clearing using ANSI escape sequences (`CLR_EOL`).
- Consistent bold cyan coloring (`CLR_SCORE`) for all score-related values.

### 🎯 Why: The user problem it solves
- Large scores (e.g., "1000000") were difficult to read at a glance during fast-paced gameplay.
- A "new personal best" lacked context without knowing what the previous record was.
- HUD updates occasionally left trailing characters from previous renders.

### ♿ Accessibility: Any a11y improvements made
- Improved readability of numeric data through standard formatting.
- Clearer visual hierarchy in the HUD through consistent color-coding of labels and values.
- More meaningful feedback for users who achieve new records.

---
*PR created automatically by Jules for task [16251212030284118581](https://jules.google.com/task/16251212030284118581) started by @aidasofialily-cmd*