### PR TITLE
🎨 Palette: Fix trailing text artifacts using ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - [Fix trailing text artifacts]
+**Learning:** To prevent trailing text artifacts in CLI applications when updating dynamic terminal lines via `\r`, always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return instead of hardcoding padding spaces.
+**Action:** Replace hardcoded space paddings with `\033[K` in standard output stream flush calls.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +108,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +141,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 **Palette: Fix trailing text artifacts using ANSI Erase in Line**

**💡 What:** 
- Replaced hardcoded spaces with the ANSI escape sequence `\033[K` (Erase in Line) when dynamically updating output lines in `src/main.cpp`. 
- Added `venv/` to `.gitignore`.
- Recorded learning in Palette's journal.

**🎯 Why:** 
In CLI applications, using `\r` to update a line with a shorter string leaves trailing artifacts from the previous string. Padding with hardcoded spaces is a brittle workaround. Using `\033[K` cleanly clears the line to the right of the cursor, preventing visual bugs when text dynamically changes size (e.g., counters or scoreboards).

**♿ Accessibility / Polish:** 
Provides a cleaner, less erratic visual presentation by removing text flicker/leftovers.

*Changes are under 50 lines and use existing system patterns.*

---
*PR created automatically by Jules for task [4920182874442091686](https://jules.google.com/task/4920182874442091686) started by @EiJackGH*