### PR TITLE
🎨 Palette: Prevent trailing text artifacts with line erase

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-04-22 - Prevent trailing text artifacts with line erase
+**Learning:** Hardcoding spaces to pad out terminal output leads to trailing artifacts when the new dynamic text is shorter.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return (`\r`) to ensure dynamic terminal lines are cleanly updated without leaving stale character artifacts.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE "" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE "" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Added the `\033[K` (Erase in Line) ANSI escape sequence to all dynamically updated terminal lines using carriage returns (`\r`).
🎯 **Why:** Previously, lines were padded with hardcoded spaces (e.g., `"GO!             "`) to hide trailing text. This was brittle. If a line was unexpectedly long and then followed by a short line, artifacts would remain on the screen, creating a poor visual UX. Using the standard "Erase in Line" ensures a clean redraw every time.
📸 **Before/After:** No visual screenshots as this is a terminal fix, but previously the transition from `[HARD MODE]` to `[NORMAL MODE]` might leave a stray `]` character. Now it is cleanly erased.
♿ **Accessibility:** Provides a cleaner, more predictable terminal output without visual clutter or stale text.

---
*PR created automatically by Jules for task [18166922043688919249](https://jules.google.com/task/18166922043688919249) started by @EiJackGH*