### PR TITLE
Fix trailing text artifacts using ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Trailing Text Artifacts in CLI
+**Learning:** In CLI applications that update dynamic lines using carriage returns (`\r`), residual characters from longer previous strings can remain at the end of the line. Using hardcoded padding spaces to clear these is brittle.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to guarantee a clean line before printing new content.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 Palette: Fix trailing text artifacts using ANSI Erase in Line

💡 **What:** 
Introduced a new macro `#define ERASE_LINE "\033[K"` and injected it into the `std::cout` stream immediately following carriage returns (`\r`). Removed the hardcoded trailing padding spaces that were previously used.

🎯 **Why:** 
In CLI applications, updating a single line repeatedly (like a countdown or a live score tracker) using `\r` can leave behind residual trailing characters if the new string is shorter than the previous one. Hardcoding blank spaces to overwrite the old characters is brittle and error-prone. The ANSI "Erase in Line" sequence (`\033[K`) natively instructs the terminal to clear from the cursor to the end of the line, ensuring a perfectly clean slate dynamically without padding.

♿ **Accessibility/UX:** 
This prevents visual artifacts and "ghost text" from appearing on the screen during gameplay loops or countdowns, ensuring a clean and polished terminal UI. A critical learning about this pattern has been recorded in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [2639711125598501783](https://jules.google.com/task/2639711125598501783) started by @EiJackGH*