### PR TITLE
🎨 Palette: Fix trailing text artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-10-25 - Preventing CLI Output Artifacts
+**Learning:** When using carriage return (`\r`) to continuously overwrite a single line in a terminal, any previous text that is longer than the new text will leave "ghost" artifacts at the end of the line. Manually hardcoding space padding is brittle and error-prone as line lengths become dynamic (e.g., growing scores).
+**Action:** Use the ANSI Escape Sequence for "Erase in Line" (`\033[K`) immediately after the carriage return (`\r`) to instantly clear the line before printing the new content. This ensures clean, dynamic UI updates without manual padding.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
### What
Added the ANSI "Erase in Line" escape sequence (`\033[K`) to terminal print statements that use carriage return (`\r`) to overwrite lines, removing the need for manual space padding.

### Why
When dynamically updating a single line in a terminal (like the score or countdown), if the new text is shorter than the old text, the remaining characters of the old text will still be visible as "ghost" artifacts. Hardcoding spaces to pad the line is brittle and can fail as lines grow or change. Using the terminal's native "Erase in Line" command ensures the line is cleanly wiped before new content is drawn.

### Accessibility/UX
Prevents confusing or ugly visual artifacts during game execution, resulting in a cleaner and more polished terminal UI.

---
*PR created automatically by Jules for task [1328771149030022744](https://jules.google.com/task/1328771149030022744) started by @EiJackGH*