### PR TITLE
🎨 Palette: Polish terminal line clear UX with ERASE_LINE

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-23 - Dynamic Line Clearing in CLI
+**Learning:** In terminal applications, updating a single line using carriage returns (`\r`) can leave trailing character artifacts if the new string is shorter than the old one. Relying on hardcoded spaces for padding is fragile and messy. Using the ANSI "Erase in Line" sequence (`\033[K`) immediately after the carriage return elegantly clears the remainder of the line, preventing any artifacting.
+**Action:** Always use the `\033[K` sequence when dynamically updating terminal lines via `\r` instead of space-padding strings.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " NEW BEST! 🥳" : "") << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
### 💡 What:
Replaced hardcoded padding spaces with the `\033[K` (Erase in Line) sequence immediately after `\r` updates in the C++ terminal loop.

### 🎯 Why:
To provide a smooth visual update when terminal lines are overwritten and prevent trailing text artifacts that occur when a new string is shorter than the old one, thus improving the UX polish.

### ♿ Accessibility:
N/A - General visual artifact polish.

---
*PR created automatically by Jules for task [11371003900664171444](https://jules.google.com/task/11371003900664171444) started by @EiJackGH*