### PR TITLE
🎨 Palette: Improve CLI readability and visual polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-04-27 - Polishing CLI Feedback with Line Clearing and Number Formatting
+**Learning:** In terminal-based UIs, especially those using carriage returns (\r) for in-place updates, visual artifacts can remain if a new string is shorter than the previous one. Using the ANSI "Erase in Line" sequence (\033[K) ensures a clean redraw. Additionally, large numeric values are much more readable at a glance when formatted with thousands separators.
+**Action:** Always append CLR_EOL (\033[K) to in-place terminal updates and use a comma-formatting helper for large numeric scores to improve readability and visual polish.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -30,6 +31,16 @@ void restore_terminal(int signum) {
     const char msg[] = "\033[0m\033[?25h\n\nGame interrupted. Terminal settings restored.\n";
     write(STDOUT_FILENO, msg, sizeof(msg) - 1);
     _exit(signum);
+}
+
+std::string formatWithCommas(long long value) {
+    std::string str = std::to_string(value);
+    int insertPosition = str.length() - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        str.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return str;
 }
 
 long long load_highscore() {
@@ -77,13 +88,13 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
-    std::cout << "Press any key to start... " << std::flush;
+    std::cout << "Press " << CLR_CTRL << "any key" << CLR_RESET << " to start... " << std::flush;
     struct pollfd start_fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     if (poll(start_fds, 1, -1) > 0) {
         if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
@@ -94,7 +105,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +119,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +152,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | "
+                      << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +166,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
💡 What: Added thousands-separator formatting for scores, highlighted interaction cues, and implemented the "Erase in Line" (CLR_EOL) sequence for cleaner terminal updates.
🎯 Why: Large numbers are hard to read at a glance during fast gameplay, and in-place terminal updates could leave visual artifacts if the new string was shorter than the old one.
♿ Accessibility: Improved visual hierarchy and readability of key game metrics and controls through color highlighting and number formatting.

---
*PR created automatically by Jules for task [9194250643765487503](https://jules.google.com/task/9194250643765487503) started by @aidasofialily-cmd*