### PR TITLE
🎨 Palette: Clean dynamic terminal lines with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Dynamic CLI Line Updates
+**Learning:** When dynamically updating a single line in a CLI application (e.g., using `\r`), relying on hardcoded padding spaces to clear previous text leads to brittle code and trailing artifacts if the new text is shorter than the old text.
+**Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return to ensure the line is cleanly cleared before rendering the new text.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
# 🎨 Palette: Micro-UX Enhancement

💡 **What:** Replaced hardcoded padding spaces with the ANSI `\033[K` (Erase in Line) escape sequence for dynamically updating terminal lines via `\r` (carriage return).
🎯 **Why:** Relying on fixed spacing to clear previous text leads to brittle UI code and visual trailing artifacts if the new line of text is shorter than the old one. The `\033[K` sequence cleanly erases from the cursor to the end of the line, ensuring a crisp, glitch-free user interface.
♿ **Accessibility/UX:** Prevents visual clutter and screen reader confusion (if applicable) caused by ghost characters left behind during rapid terminal updates, such as the countdown and score tracking in the CLI game loop.

---
*PR created automatically by Jules for task [10264327440364780979](https://jules.google.com/task/10264327440364780979) started by @EiJackGH*