### PR TITLE
🎨 Palette: Improved numeric readability and visual polish

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -30,6 +31,22 @@ void restore_terminal(int signum) {
     const char msg[] = "\033[0m\033[?25h\n\nGame interrupted. Terminal settings restored.\n";
     write(STDOUT_FILENO, msg, sizeof(msg) - 1);
     _exit(signum);
+}
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    std::string res = "";
+    int count = 0;
+    for (int i = s.length() - 1; i >= 0; i--) {
+        res += s[i];
+        count++;
+        if (count % 3 == 0 && i != 0) {
+            res += ",";
+        }
+    }
+    if (value < 0) res += "-";
+    std::reverse(res.begin(), res.end());
+    return res;
 }
 
 long long load_highscore() {
@@ -77,7 +94,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +111,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +125,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +158,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +172,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces a series of micro-UX improvements to the "Speed Clicker" CLI game, focusing on readability and visual polish.

### 💡 What:
- **Digit Grouping:** All scores (Personal Best, current HUD score, and final summary) now include thousands separators (e.g., `1,234` instead of `1234`).
- **Visual Polish:** Replaced manual space-padding with the ANSI "Erase in Line" (`\033[K`) sequence to prevent visual artifacts during state transitions (e.g., countdown to "GO!").
- **Consistency:** Applied `CLR_SCORE` (Bold Cyan) consistently across HUD labels and values for better visual balance.
- **Achievement Context:** When a new personal best is achieved, the game-over screen now displays the previous record for immediate progress comparison.

### 🎯 Why:
- Large numbers are difficult to parse quickly in a high-speed game. Thousands separators significantly improve "at-a-glance" readability.
- Terminal ghost characters from previous lines can be distracting; explicit line clearing ensures a professional, "clean" feel.
- Contextual achievement feedback ("Previous: X") provides a more satisfying sense of progress.

### ♿ Accessibility:
- Improved color contrast and consistency in the terminal HUD.
- Better visual hierarchy using standard ANSI bold colors for key interactive elements.

---
*PR created automatically by Jules for task [1162261904392563429](https://jules.google.com/task/1162261904392563429) started by @aidasofialily-cmd*