### PR TITLE
🎨 Palette: Improve score readability and terminal UI stability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Thousands Separators for Readability
+**Learning:** In CLI games with escalating numeric values, thousands separators are essential for readability. Furthermore, using ANSI escape sequences like `\033[K` (CLR_EOL) prevents visual "ghosting" when lines change length, ensuring a polished and professional feel.
+**Action:** Implement thousands-separator formatting for all large numbers and use `CLR_EOL` when performing in-place terminal line updates.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -50,6 +51,16 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = s.length() - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +105,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -141,10 +152,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << " | High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +165,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces several micro-UX improvements to the Speed Clicker game to enhance readability and visual polish.

### 💡 What
- **Thousands Separators:** Added a `formatWithCommas` helper to format scores (e.g., `1,000` instead of `1000`) in the header, HUD, and final results.
- **Terminal Stability:** Defined and used a `CLR_EOL` macro (`\033[K`) to clear any leftover characters from previous lines when updating the HUD or countdown.
- **Visual Consistency:** Styled the HUD labels and values uniformly with `CLR_SCORE` (Bold Cyan) for a more balanced look.
- **Achievement Context:** Updated the game-over message to show the user's previous personal best when they break their record.

### 🎯 Why
- Large numbers without separators are difficult to read at a glance, especially in a fast-paced game.
- In-place terminal updates with `\r` can leave trailing characters from previous, longer lines, creating a messy UI.
- Consistent coloring improves the hierarchy and readability of the game state.
- Providing the previous record adds a sense of progress and accomplishment.

### ♿ Accessibility
- Improved readability of numeric data through standard formatting.
- Ensured a more stable and predictable terminal display by preventing visual artifacts.

Verified with unit tests for the formatting logic and a UX validation script for terminal behavior.

---
*PR created automatically by Jules for task [4277778065469207384](https://jules.google.com/task/4277778065469207384) started by @aidasofialily-cmd*