### PR TITLE
🎨 Palette: Add ERASE_LINE macro to prevent trailing artifacts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-23 - Preventing Trailing Artifacts in Dynamic CLI Lines
+**Learning:** When using the carriage return (`\r`) to continuously update a single line in a terminal application, replacing longer strings with shorter strings will leave trailing artifacts if not handled properly. Relying on hardcoded padding spaces (e.g., `"GO!             "`) is brittle and prone to failure if the string length variations are miscalculated. The ANSI "Erase in Line" sequence (`\033[K`) provides a robust, native solution to clear from the cursor to the end of the line, guaranteeing a clean visual state.
+**Action:** Always use `\033[K` immediately after a carriage return when dynamically updating lines in a CLI application, rather than relying on manual space padding.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
## 💡 What
Added an `ERASE_LINE` macro (`\033[K`) to `src/main.cpp` and used it alongside carriage returns (`\r`) to dynamically update terminal lines instead of padding with spaces.

## 🎯 Why
In terminal applications updating a single line continuously, replacing longer strings with shorter strings leaves behind trailing artifacts from the previous render. Relying on hardcoded space padding (e.g., `"GO!             "`) is brittle. The ANSI "Erase in Line" sequence provides a native, robust solution to clear from the cursor to the end of the line, guaranteeing a clean visual state.

## ♿ Accessibility / UX
Ensures text remains sharp and free of visual clutter during rapid screen updates, enhancing focus and readability for users of the CLI interface.

---
*PR created automatically by Jules for task [1706156746202242104](https://jules.google.com/task/1706156746202242104) started by @EiJackGH*