### PR TITLE
🎨 Palette: Prevent trailing text artifacts with ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-01 - Prevent trailing text artifacts in CLI
+**Learning:** Using the ANSI escape sequence `\033[K` (Erase in Line) is a cleaner and more robust way to prevent trailing text artifacts when updating dynamic terminal lines via carriage return `\r`, compared to hardcoding padding spaces.
+**Action:** Implement an `ERASE_LINE` macro and use it immediately after `\r` on any dynamically updated terminal output.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 **Palette: Prevent trailing text artifacts in CLI**\n\n💡 **What:** Added the ANSI "Erase in Line" escape sequence (`\\033[K`) to dynamically updated terminal outputs (like the startup countdown, "GO!" message, and live score updates).\n\n🎯 **Why:** Previously, the application relied on hardcoded padding spaces (e.g., `<< "           "`) to overwrite trailing characters from previous outputs when using a carriage return (`\\r`). This is brittle and can lead to visual artifacts if the new string isn\'t long enough or if the terminal behaves unexpectedly. Using the standard ANSI sequence explicitly clears everything from the cursor to the end of the line, providing a much cleaner, robust, and artifact-free visual experience during rapid updates.\n\n♿ **Accessibility/UX:** Improves visual clarity and prevents confusing artifacting for all terminal users.

---
*PR created automatically by Jules for task [1290111459588746661](https://jules.google.com/task/1290111459588746661) started by @EiJackGH*