### PR TITLE
🎨 Palette: CLI HUD and Score Readability Enhancement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Enhancing CLI Readability and Polish
+**Learning:** In terminal UIs, large numbers are hard to parse at a glance. Implementing a comma-formatter () improves instant readability. Additionally, using `CLR_EOL` (`\033[K`) when updating lines with `\r` is a more robust way to ensure clean UI refreshes than relying on trailing spaces, especially when the new content might be shorter than the old.
+**Action:** Use a thousands-separator helper for all numeric displays in CLI apps and prioritize `CLR_EOL` for flicker-free line updates.
+
+## 2024-05-24 - Enhancing CLI Readability and Polish
+**Learning:** In terminal UIs, large numbers are hard to parse at a glance. Implementing a comma-formatter (`formatWithCommas`) improves instant readability. Additionally, using `CLR_EOL` (`\033[K`) when updating lines with `\r` is a more robust way to ensure clean UI refreshes than relying on trailing spaces, especially when the new content might be shorter than the old.
+**Action:** Use a thousands-separator helper for all numeric displays in CLI apps and prioritize `CLR_EOL` for flicker-free line updates.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    int n = s.length() - 3;
+    while (n > 0) {
+        s.insert(n, ",");
+        n -= 3;
+    }
+    if (value < 0) s.insert(0, "-");
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,13 +89,13 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
-    std::cout << "Press any key to start... " << std::flush;
+    std::cout << "Press " << CLR_CTRL << "[any key]" << CLR_RESET << " to start... " << std::flush;
     struct pollfd start_fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     if (poll(start_fds, 1, -1) > 0) {
         if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" << CLR_EOL << "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -141,10 +153,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_EOL << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " " CLR_NORM "NEW BEST! 🥳" CLR_RESET : "")
+                      << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +166,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
🎨 Palette: CLI HUD and Score Readability Enhancement

This PR introduces several micro-UX improvements to the SPEED CLICKER game to enhance readability and visual polish:

- **Score Readability:** Added a `formatWithCommas` helper function to display scores with thousands separators.
- **Robust Rendering:** Introduced the `CLR_EOL` macro for cleaner line updates in the terminal.
- **Visual Hierarchy:** Improved color usage for interactive prompts and HUD labels.
- **Achievement Context:** Display previous personal best on the Game Over screen.

---
*PR created automatically by Jules for task [10282424978381435766](https://jules.google.com/task/10282424978381435766) started by @aidasofialily-cmd*