### PR TITLE
🎨 Palette: Clean dynamic terminal updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-07 - Clean dynamic terminal updates
+**Learning:** Using carriage return (\r) with hardcoded padding spaces for dynamic terminal line updates can leave trailing artifacts and is brittle.
+**Action:** Always use the ANSI escape sequence \033[K (Erase in Line) immediately after the carriage return to ensure the line is cleanly overwritten, preventing visual artifacts in CLI applications.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 
 // Color and formatting macros for terminal output
 #define RESET     "\033[0m"
+#define ERASE_LINE "\033[K"
 #define RED       "\033[31m"
 #define GREEN     "\033[32m"
 #define YELLOW    "\033[33m"
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 Palette: Fix dynamic terminal trailing artifacts using ERASE_LINE

💡 What: Replaced hardcoded padding spaces with the ANSI escape sequence \033[K (Erase in Line) during dynamic terminal updates (\r).
🎯 Why: When a shorter string replaced a longer string, trailing visual artifacts remained on the screen. The erase sequence ensures the line is cleanly overwritten.
♿ Accessibility: Improves visual clarity and prevents confusing residual characters during rapid updates.

---
*PR created automatically by Jules for task [11865295645884294300](https://jules.google.com/task/11865295645884294300) started by @EiJackGH*