### PR TITLE
🎨 Palette: Cleanly erase dynamic lines to prevent text artifacts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Trailing Text Artifacts in Dynamic Terminal Lines
+**Learning:** Hardcoding padding spaces to overwrite previous text lines in dynamic terminal outputs (like score updates) is error-prone and can leave trailing artifacts if the new string is shorter than the old one, plus it's difficult to maintain.
+**Action:** Use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return `\r` to cleanly clear the line before printing new content.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
**🎨 Palette: Fix trailing text artifacts in dynamic lines**

**💡 What:**
Replaced hardcoded padding spaces with the standard ANSI escape sequence `\033[K` (Erase in Line) immediately following the carriage return `\r` on dynamic status lines (the countdown, the "GO!" line, and the live score tracker).

**🎯 Why:**
When dynamic lines in terminal applications update in place, writing a shorter string over a longer string leaves trailing text artifacts from the previous rendering. Using `\033[K` ensures the line is cleanly cleared before new output is flushed, resulting in a cleaner UI, avoiding layout jumps, and making the code more robust against future changes to status strings.

**♿ Accessibility & UX:**
Improves the tactile feedback and visual polish of the CLI experience by keeping dynamic elements sharp and free of lingering characters.

---
*PR created automatically by Jules for task [13662169692107156201](https://jules.google.com/task/13662169692107156201) started by @EiJackGH*