### PR TITLE
🎨 Palette: Enhance score readability and HUD visuals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-05-24 - Visual Polish with Erase in Line (EL)
+**Learning:** When using carriage returns (\r) for in-place terminal updates, shorter subsequent strings can leave "ghost" characters from the previous longer output. Using the ANSI escape sequence \033[K (Erase in Line) at the start or end of the update ensures a clean, flicker-free transition without needing to pad with spaces.
+**Action:** Always append or prepend CLR_EOL (\033[K) when performing in-place terminal updates to ensure visual consistency.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,9 +20,20 @@
 #define CLR_HARD  "\033[1;31m"
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
+#define CLR_EOL   "\033[K"
 #define CLR_RESET "\033[0m"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    int n = s.length();
+    for (int i = n - 3; i > 0; i -= 3) {
+        s.insert(i, ",");
+    }
+    if (value < 0) s.insert(0, "-");
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +105,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" << CLR_EOL << "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +119,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_EOL << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +152,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << CLR_RESET << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +166,10 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best! " << CLR_RESET
+                  << "(Previous: " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces several micro-UX improvements to the SPEED CLICKER terminal game:

- **Numeric Readability**: Scores and high scores are now formatted with thousands separators (e.g., "1,000" instead of "1000") using a new `formatWithCommas` helper.
- **Terminal Polish**: Utilized the `CLR_EOL` (\033[K) escape sequence to ensure that in-place line updates (like the HUD and countdown) are clean and don't leave "ghost" characters from previous, longer lines.
- **Achievement Context**: When a new personal best is achieved, the game-over screen now displays the previous record alongside the new score, providing immediate context for the accomplishment.
- **Visual Consistency**: The HUD labels ("Score:", "High:") are now consistently styled with `CLR_SCORE`, and the "NEW BEST!" notification is highlighted in `CLR_NORM`.
- **Accessibility**: Improved visual hierarchy in the terminal output through consistent use of color and clear line transitions.

---
*PR created automatically by Jules for task [11150111134612690362](https://jules.google.com/task/11150111134612690362) started by @aidasofialily-cmd*