### PR TITLE
🎨 Palette: Clean CLI updates using Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-09 - Clean Terminal Line Updating
+**Learning:** Hardcoding spaces (e.g., `"           "`) at the end of dynamically updating terminal lines (like timers or score counters) is a fragile way to overwrite previous text. If the new line is shorter than the old line minus the padding, artifacts (trailing characters) remain on the screen, creating a messy visual experience.
+**Action:** Always use the ANSI "Erase in Line" escape sequence (`\033[K`) immediately after a carriage return (`\r`) to completely clear the line before printing new, dynamic content in CLI applications. This ensures clean updates regardless of line length variations.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 Palette: Use Erase in Line escape sequence for clean CLI updates

💡 What: Replaced hardcoded padding spaces with the ANSI "Erase in Line" escape sequence (`\033[K`) for all dynamically updated terminal lines (timer, GO message, and score counter). Also added `venv/` to `.gitignore`.
🎯 Why: Hardcoded padding is fragile. If a new string is shorter than the previous string minus the padding, trailing character artifacts remain on the screen. The `\033[K` sequence ensures the rest of the line is cleanly erased before printing, resulting in a cleaner, glitch-free visual experience.
♿ Accessibility: Reduces visual noise and cognitive load by ensuring terminal output is clean and free of leftover artifacts.

---
*PR created automatically by Jules for task [16501727679600172285](https://jules.google.com/task/16501727679600172285) started by @EiJackGH*