### PR TITLE
🎨 Palette: Improve CLI readability and visual feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-21 - Readability of Large Numbers in CLI
+**Learning:** As numeric values escalate in games or data-heavy CLI tools, raw integers become increasingly difficult to parse quickly. Implementing a thousands-separator formatter significantly enhances readability and professional feel.
+**Action:** Always format large numeric values with thousands-separators in CLI displays to improve immediate data comprehension.
+
+## 2026-06-21 - Visual Hygiene with Carriage Returns
+**Learning:** When using `\r` for in-place terminal updates, shorter new lines can leave "ghost" characters from previous, longer lines. Using the ANSI "Clear to End of Line" escape sequence (`\033[K`) is more robust than manual padding with spaces.
+**Action:** Define a `CLR_EOL` macro and use it at the end of every carriage-returned terminal output line to ensure a clean visual state.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,32 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    if (value == 0) return "0";
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int start = (value < 0) ? 1 : 0;
+    int num_digits = n - start;
+    int num_commas = (num_digits - 1) / 3;
+    int res_len = n + num_commas;
+    std::string res(res_len, ' ');
+
+    int j = res_len - 1;
+    int count = 0;
+    for (int i = n - 1; i >= start; i--) {
+        res[j--] = s[i];
+        if (++count == 3 && i > start) {
+            res[j--] = ',';
+            count = 0;
+        }
+    }
+    if (value < 0) res[0] = '-';
+    return res;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,13 +101,13 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
               << CLR_CTRL << "[q]" << CLR_RESET << " Quit Game\n " << CLR_CTRL << "[Any key]" << CLR_RESET << " Click!\n\n";
 
-    std::cout << "Press any key to start... " << std::flush;
+    std::cout << "Press " << CLR_CTRL << "any key" << CLR_RESET << " to start... " << std::flush;
     struct pollfd start_fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     if (poll(start_fds, 1, -1) > 0) {
         if (read(STDIN_FILENO, &input, 1) > 0 && input == 'q') {
@@ -94,7 +118,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -141,10 +165,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << CLR_RESET << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +179,10 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET
+                  << " (Previous: " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 🎨 Palette: Improve CLI readability and visual feedback

#### 💡 What: The UX enhancement added
Enhanced the terminal-based "Speed Clicker" game with a suite of micro-UX improvements focused on readability, feedback, and visual hygiene.

Key changes include:
- **Numeric Formatting**: Scores and high scores are now formatted with thousands-separators (e.g., `1,234` instead of `1234`).
- **Terminal Hygiene**: Defined a `CLR_EOL` macro (`\033[K`) for use with carriage returns, ensuring clean HUD updates without character ghosting.
- **Visual Hierarchy**: Colorized interactive keywords (e.g., "[any key]") and feedback indicators ("NEW BEST!") using the project's color palette.
- **Contextual Feedback**: The game-over screen now displays the previous personal best alongside the new score, providing meaningful context for achievements.

#### 🎯 Why: The user problem it solves
- **Readability**: Large, raw integers are difficult to parse quickly in a fast-paced game. Thousands-separators make values immediately comprehensible.
- **Visual Clarity**: Inconsistent colors and "ghosting" from previous terminal lines can be distracting and unprofessional.
- **Engagement**: Clearer success indicators and contextual history (previous record) make the experience more rewarding.

#### ♿ Accessibility: Any a11y improvements made
- Improved cognitive load and data comprehension by formatting large numbers into standard, readable chunks.
- Enhanced visual cues for interactive elements, making it easier for users to identify how to proceed.


---
*PR created automatically by Jules for task [9685499750417517880](https://jules.google.com/task/9685499750417517880) started by @aidasofialily-cmd*