### PR TITLE
🎨 Palette: Prevent trailing text artifacts on dynamic CLI updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-25 - Prevent Trailing Text Artifacts on Dynamic CLI Lines
+**Learning:** When creating a dynamic line using carriage returns (`\r`), previously printed text that is longer than the new text will leave trailing artifacts on the screen. Using arbitrary spaces to pad the new line is error-prone and can cause unexpected wrapping.
+**Action:** Use the ANSI "Erase in Line" escape sequence (`\033[K`) immediately after the carriage return (`\r`) to ensure the line is fully cleared before writing the new frame, providing a much cleaner and robust rendering method.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
**💡 What:** Replaced arbitrary whitespace padding (e.g., `"GO!             "`) with the ANSI "Erase in Line" escape sequence (`\033[K`) for all dynamically updated lines using carriage returns (`\r`).
**🎯 Why:** When updating a terminal line in place, if the new text is shorter than the previously printed text, the leftover characters from the old string will remain visible as a trailing artifact. Padding with spaces is a fragile workaround that can cause unintended line wrapping on smaller terminal widths. `\033[K` is a robust, terminal-native solution that cleanly clears the rest of the line before drawing the new frame, providing a much cleaner rendering method.
**♿ Accessibility:** N/A (Visual clarity/rendering bugfix).

---
*PR created automatically by Jules for task [17354432892459970733](https://jules.google.com/task/17354432892459970733) started by @EiJackGH*