### PR TITLE
🎨 Palette: Improve dynamic CLI output using ANSI Erase in Line

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Dynamic Line Erasing in CLI
+**Learning:** When creating dynamic, single-line updating outputs (like progress bars, countdowns, or live score trackers) in a CLI using `\r` to return the cursor to the start of the line, manually padding the output with spaces to clear previous text is brittle and leads to visual artifacts if the new string is shorter than the old one.
+**Action:** Instead of hardcoding padding spaces, always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return `\r` to ensure the rest of the line is cleanly erased before drawing the new content.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** Replaced hardcoded padding spaces with the ANSI `\033[K` (Erase in Line) sequence when dynamically updating lines (like the countdown timer and live score display) using carriage returns (`\r`).

🎯 **Why:** When rapidly updating a single line in a terminal by returning the cursor to the beginning (using `\r`), padding the output with blank spaces to cover up the previous text is brittle. If the new string is shorter than the old one, and the padding isn't perfectly calculated, "ghost text" artifacts remain. Using the ANSI "Erase in Line" sequence ensures the line is cleanly cleared from the cursor onward, providing a much cleaner and more resilient visual update.

📸 **Before/After:** (Visual change only visible when text length dynamically shrinks, preventing trailing character artifacts)

♿ **Accessibility:** Cleaner visual updates reduce flickering and visual clutter, making the interface slightly more pleasant to focus on.

---
*PR created automatically by Jules for task [12546085899735205054](https://jules.google.com/task/12546085899735205054) started by @EiJackGH*