### PR TITLE
🎨 Palette: Use Erase in Line for cleaner UI updates

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-28 - Preventing Terminal Artifacts
+**Learning:** Hardcoding trailing spaces to overwrite previous terminal output is brittle and can still leave artifacts if the new string is significantly shorter. The ANSI 'Erase in Line' sequence (`\033[K`) is a robust, dynamic way to clear the remainder of a line.
+**Action:** Always use `\033[K` immediately after a carriage return (`\r`) when dynamically updating a single line in CLI applications, rather than relying on manual space padding.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -94,7 +95,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +109,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE "" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +142,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE "" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 Palette: Use Erase in Line for cleaner UI updates

### 💡 What:
Replaced hardcoded padding spaces (e.g., `"           "`) in dynamic UI updates with the ANSI "Erase in Line" escape sequence (`\033[K`), defined as the macro `ERASE_LINE`.

### 🎯 Why:
Using space padding is a brittle way to clear old text when rendering a new frame in a CLI. If the previous text (e.g., a high score or a long status message) is longer than the padding provided, trailing artifacts remain on the screen. The ANSI `\033[K` sequence dynamically clears everything from the cursor to the end of the line, ensuring a visually clean update every time regardless of string length.

### ♿ Accessibility & Polish:
- Eliminates visual clutter and ghost text, making the UI much cleaner and reducing cognitive load.
- Added a new journal entry to `.Jules/palette.md` to document this CLI interaction best practice.

---
*PR created automatically by Jules for task [12783762694934194093](https://jules.google.com/task/12783762694934194093) started by @EiJackGH*