### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-28 - Explicit Empty States for Onboarding
+**Learning:** In CLI applications, hiding UI elements like "Personal Best" when data is empty (score = 0) can confuse new users about what goals exist. Explicit, encouraging empty states clarify system state and improve user onboarding.
+**Action:** Provide explicit empty states (e.g., "None yet! Go set one!") rather than omitting the UI element when data is missing.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**What:** Added an explicit empty state ("Personal Best: None yet! Go set one!") for users playing the game for the first time without an existing highscore.

**Why:** In CLI applications, hiding UI elements when data is empty can confuse users about what goals exist. Explicit, encouraging empty states clarify system state and improve user onboarding.

**Accessibility/UX:** Improves onboarding experience and clarifies application goals for new users. Added a critical learning entry to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [8991862213060794504](https://jules.google.com/task/8991862213060794504) started by @EiJackGH*