### PR TITLE
🎨 Palette: Add explicit empty state for personal best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-18 - Explicit Empty States
+**Learning:** Hiding UI elements like "Personal Best" when empty can confuse users about what's available. Explicit empty states improve clarity and encourage user interaction.
+**Action:** Provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet. Play to set a score!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state message for the "Personal Best" line when the user has not set a high score yet (highscore is 0).
🎯 Why: Hiding UI elements like "Personal Best" when empty can confuse users about what features or metrics are available. Providing an explicit, encouraging message clarifies the system state and encourages the user to play.
📸 Before/After: Visual change in terminal output. Before, it was hidden. Now, it displays: "Personal Best: None yet. Play to set a score!".
♿ Accessibility: Improves cognitive accessibility by explicitly stating the current condition rather than relying on absence of information.

---
*PR created automatically by Jules for task [5884562416530523435](https://jules.google.com/task/5884562416530523435) started by @EiJackGH*