### PR TITLE
🎨 Palette: Add explicit empty state for Personal Best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-19 - Explicit Empty States
+**Learning:** Hiding UI elements like high scores when empty can confuse users about what is achievable. Explicitly showing "None yet" provides clarity and onboarding encouragement.
+**Action:** Always provide an explicit empty state for data or achievements instead of hiding the UI element entirely.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Added an explicit empty state ("None yet! Set a record!") for the Personal Best score.
🎯 **Why**: Previously, if a user had no high score, the UI element was completely hidden. This hides the achievable goal from new users. Explicit empty states are a UX best practice to encourage onboarding.
♿ **Accessibility**: Provides clearer context to users about the state of the game without relying on assumed knowledge.

---
*PR created automatically by Jules for task [13557960273016011358](https://jules.google.com/task/13557960273016011358) started by @EiJackGH*