### PR TITLE
🎨 Palette: Improve score readability and terminal UI transitions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Clean Terminal UI Transitions
+**Learning:** Overwriting terminal lines with shorter strings (e.g., "GO!" over "Starting in 3...") leaves "ghost characters" from the previous longer line. Using the ANSI 'Erase in Line' sequence (\033[K) ensures a clean transition. Additionally, formatting large numbers with thousand-separators and providing historical context (e.g., "Previous Best") on achievement screens deepens the user's sense of progress.
+**Action:** Always use CLR_EOL when performing in-place terminal updates and apply numeric formatting to any potentially large integer values for better scanability.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = static_cast<int>(s.length());
+    int insertPosition = n - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" << CLR_EOL << "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_EOL << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_EOL << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,10 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET
+                  << " (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 🎨 Palette: Improve score readability and terminal UI transitions

#### 💡 What:
Improved the visual experience of the SPEED CLICKER CLI game by adding thousands-separators to numeric values and cleaning up terminal rendering.

#### 🎯 Why:
- **Readability:** High scores in clicker games quickly become hard to read without digit grouping (e.g., 1000 vs 1,000).
- **Visual Polish:** Overwriting "Starting in 3..." with "GO!" left trailing characters on the terminal line. Using `\033[K` ensures a clean erase.
- **Player Context:** Showing the previous personal best when a new record is set provides immediate satisfaction and context for the achievement.

#### ♿ Accessibility:
- Improved color contrast for HUD elements.
- Better visual scanning of large numbers through grouping.

#### 🛠️ Changes:
- Added `formatWithCommas` utility in `src/main.cpp`.
- Added `CLR_EOL` macro for terminal line clearing.
- Updated countdown, HUD, and game-over screens.

---
*PR created automatically by Jules for task [8931579248761496065](https://jules.google.com/task/8931579248761496065) started by @aidasofialily-cmd*