### PR TITLE
🎨 Palette: Add explicit empty state for zero highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Explicit Empty States
+**Learning:** Users need clear feedback when starting fresh. Hiding UI elements (like a high score) when empty creates confusion about system capabilities.
+**Action:** Always provide explicit, encouraging empty states (e.g., "None yet! Go set one!") rather than omitting the UI element entirely.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Go set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
This PR adds a micro-UX improvement by providing an explicit empty state when the user has no highscore.

💡 **What:** Added an `else` branch to display an encouraging "None yet! Go set one!" message when the highscore is 0.
🎯 **Why:** Users need clear feedback when starting fresh. Hiding UI elements when empty creates confusion about system capabilities.
♿ **Accessibility/Usability:** Improves the first-time user experience and onboarding by confirming the system's state immediately upon launch rather than hiding it.

---
*PR created automatically by Jules for task [8087881474382190958](https://jules.google.com/task/8087881474382190958) started by @EiJackGH*