### PR TITLE
🎨 Palette: Add thousands separators for score readability

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -48,6 +49,17 @@ void save_highscore(long long score) {
         file << score;
         file.close();
     }
+}
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
 }
 
 int main() {
@@ -141,10 +153,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +166,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
💡 What: Added a `formatWithCommas` helper function to format large scores with thousands separators (e.g., 1,000,000 instead of 1000000). Also introduced a `CLR_EOL` macro to use the ANSI "Erase in Line" sequence for cleaner terminal updates in the HUD.
🎯 Why: Improving numeric readability is crucial as scores escalate in SPEED CLICKER. Using `CLR_EOL` prevents visual ghosting from previous longer lines without relying on manual space padding.
♿ Accessibility: Better readability for large numbers and a cleaner terminal interface.

---
*PR created automatically by Jules for task [14440762112591084652](https://jules.google.com/task/14440762112591084652) started by @aidasofialily-cmd*