### PR TITLE
🎨 Palette: Explicit Empty State for High Score Onboarding

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Explicit Empty States for Onboarding
+**Learning:** In terminal applications, providing explicit, encouraging empty states for data or achievements (like a high score) rather than hiding the UI element when empty clarifies system state and improves user onboarding.
+**Action:** Always display placeholder text or calls to action when data is absent to guide new users.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Implemented an explicit empty state for the personal best score. When `highscore == 0`, instead of rendering nothing, the game now displays: `Personal Best: None yet! Go set a record!`. Also appended a UX learning entry to `.Jules/palette.md`.
🎯 Why: To improve onboarding and clarity for first-time users. Explicit empty states provide helpful calls-to-action and make the UI's purpose clearer than simply hiding elements when data is absent.
📸 Before/After: Not applicable (terminal-based UI).
♿ Accessibility: Improves clarity of system state for new users.

---
*PR created automatically by Jules for task [12919874414959812278](https://jules.google.com/task/12919874414959812278) started by @EiJackGH*