### PR TITLE
🎨 Palette: Add explicit empty state for Personal Best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-15 - Explicit Empty State for Achievements
+**Learning:** When users have not achieved a score yet, hiding the section makes the system state unclear.
+**Action:** Added an explicit, encouraging empty state (e.g., "None yet! Set a record!") to clarify the state and improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state ("None yet! Set a record!") for the Personal Best section when the high score is zero.
🎯 Why: Previously, the section was simply hidden. Hiding UI elements for achievements when empty makes the system state unclear and hurts onboarding.
♿ Accessibility/UX: Provides an encouraging, explicit empty state that clarifies the system's tracking mechanism for new users.

---
*PR created automatically by Jules for task [1077829044956618824](https://jules.google.com/task/1077829044956618824) started by @EiJackGH*