### PR TITLE
🎨 Palette: Add empty state for progression highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-05-23 - Empty States for Progression
+**Learning:** In CLI games with progression or high scores, an empty state (e.g., 'None yet! Play to set one!') is more encouraging and intuitive for first-time users than simply omitting the data field. It explicitly tells the user what the missing data represents and how to achieve it.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Play to set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Added an explicit empty state string to the `Personal Best` display when the high score is zero, replacing the previous behavior of completely hiding the UI element. Also recorded this as a learning in `.Jules/palette.md`.
🎯 **Why**: In CLI games with progression, empty states (e.g., 'None yet! Play to set one!') are more encouraging and intuitive for first-time users than omitting data. It explicitly tells the user what the missing data represents and how to achieve it.
♿ **Accessibility**: Provides immediate visual clarity to new users about the state of the system rather than leaving them guessing about what UI elements are present.

---
*PR created automatically by Jules for task [7226088526253553195](https://jules.google.com/task/7226088526253553195) started by @EiJackGH*