### PR TITLE
🎨 Palette: [UX improvement] Enhance score readability and terminal polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-05-24 - Robust Terminal Line Clearing
+**Learning:** Using space-padding to "clear" previous content when using carriage returns (`\r`) in terminal UIs is fragile, as it requires knowing the maximum possible length of the previous line. Utilizing the ANSI 'Erase in Line' escape sequence (`\033[K`) via a `CLR_EOL` macro is a much more robust UX practice that guarantees the removal of all stale characters from the cursor position to the end of the line.
+**Action:** Use `CLR_EOL` (ANSI `\033[K`) for all in-place terminal updates to ensure a clean interface across variable-length output states.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,19 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +105,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +119,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +152,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << " | High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +166,12 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best! 🏆" << CLR_RESET << "\n";
+        if (initialHighscore > 0) {
+            std::cout << "(Previous Best: " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << ")\n";
+        }
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR introduces several micro-UX improvements to Speed Clicker to enhance readability and visual polish.

### 💡 What:
- **Thousand Separators:** Added a `formatWithCommas` utility to all score displays (Personal Best, live Score, and Final Score).
- **Robust Line Clearing:** Replaced manual space padding with the `CLR_EOL` ANSI escape sequence (`\033[K`) for cleaner in-place terminal updates.
- **Achievement Context:** Updated the game-over screen to display the previous personal best when a new record is achieved.
- **Visual Consistency:** Applied consistent `CLR_SCORE` (Bold Cyan) styling to score labels and values.

### 🎯 Why:
- **Readability:** Large numbers (e.g., 1000000) are difficult to parse at a glance in a fast-paced game. Comma formatting makes them immediate.
- **Visual Polish:** Manual space padding often leaves "ghost characters" if the new line is shorter than the previous one. `CLR_EOL` guarantees a clean line.
- **Engagement:** Showing the previous record alongside a new best provides meaningful context for the player's achievement.

### ♿ Accessibility:
- Consistent use of bold colors for labels and values improves visual hierarchy.
- Clearer terminal transitions reduce visual noise for all users.

---
*PR created automatically by Jules for task [15758534672756313589](https://jules.google.com/task/15758534672756313589) started by @aidasofialily-cmd*