### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-10-24 - Empty States as Onboarding
+**Learning:** In CLI applications, explicitly displaying empty states (e.g., a score of 0 with an encouraging message) provides better onboarding than hiding the UI element entirely. It clarifies the system state and motivates the user.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "0 (None yet, go get 'em!)" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**💡 What:** Added an explicit empty state message ("0 (None yet, go get 'em!)") for the highscore when it is exactly 0.
**🎯 Why:** Hiding the high score entirely when it's 0 can be confusing for first-time players. Displaying a clear, encouraging empty state provides better onboarding and clarifies the system's tracking state.
**📸 Before/After:** Before, the highscore line was simply omitted if the score was 0. After, it explicitly shows a zero score with a fun message.
**♿ Accessibility:** N/A (CLI text clarity improvement).

---
*PR created automatically by Jules for task [15333306895572769228](https://jules.google.com/task/15333306895572769228) started by @EiJackGH*