### PR TITLE
🎨 Palette: Add encouraging empty state for initial high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-25 - Encouraging Empty States in CLI
+**Learning:** In terminal applications, displaying a welcoming empty state for missing data (e.g., "None yet! Start clicking!" instead of hiding the high score section entirely) improves user onboarding and clearly indicates the system state.
+**Action:** Provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Start clicking!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**What:** Added an encouraging empty state ("None yet! Start clicking!") for the "Personal Best" section when the high score is zero.
**Why:** To improve onboarding and clarify to the user that the system tracks high scores, rather than just hiding the section.
**Before/After:** The "Personal Best" section is now visible even on the first run.
**Accessibility:** Improves clarity of system state for all users.

---
*PR created automatically by Jules for task [14713006375281338759](https://jules.google.com/task/14713006375281338759) started by @EiJackGH*