### PR TITLE
🎨 Palette: Add thousands separators and achievement context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-16 - Readability and Achievement Context in CLI
+**Learning:** As scores in CLI games escalate, large numbers become difficult to parse at a glance. Thousands separators are essential for readability. Additionally, providing immediate context (like showing the previous personal best) when a new record is achieved reinforces the sense of accomplishment.
+**Action:** Use a `formatWithCommas` utility for all significant numeric displays and include comparative "Previous Best" markers when celebrating new records.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,17 @@
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 struct termios oldt;
 
 void restore_terminal(int signum) {
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,9 +152,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
                       << "           " << std::flush;
             updateUI = false;
         }
@@ -154,9 +166,12 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET << "\n";
+        if (initialHighscore > 0) {
+            std::cout << "(Previous Best: " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << ")\n";
+        }
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
💡 **What**: Added thousands-separator formatting for all score displays and enhanced the game-over screen to show the previous personal best when a new record is achieved. Also standardized HUD colors and fixed potential color bleed.

🎯 **Why**: As scores escalate, they become harder to read at a glance; commas improve immediate readability. Providing the previous best score on the game-over screen gives players meaningful achievement context.

♿ **Accessibility**: Improved visual contrast and clarity by colorizing both labels and values consistently in the HUD, and ensured terminal state is cleanly reset to prevent color-blindness-unfriendly color bleed in the user's shell.

---
*PR created automatically by Jules for task [5773720821678146816](https://jules.google.com/task/5773720821678146816) started by @aidasofialily-cmd*