### PR TITLE
🎨 Palette: Add explicit empty state for highscore and improve terminal rendering

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-27 - Empty States as Onboarding
+**Learning:** In applications that rely on persistent achievements (like high scores), hiding the UI element when the data is missing (e.g., first-time user) misses an opportunity to clarify the system's goals. Providing an explicit, encouraging empty state (like "None yet! Play to set a record!") helps orient new users and gives them a clear immediate objective, vastly improving the onboarding experience compared to just a blank space.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element, especially for core gamified loops.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -78,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +97,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +111,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +144,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What**: Added an explicit "None yet! Play to set a record!" message when the highscore is 0, and replaced hardcoded trailing spaces with an ANSI ERASE_LINE (`\033[K`) macro for line clearing.
🎯 **Why**: To improve onboarding by providing a clear, encouraging objective for new users rather than a blank UI space. The ERASE_LINE macro robustly fixes text bleed-through when terminal output shrinks in length.
📸 **Before/After**: 
- Before: Blank space where highscore should be for new users; brittle hardcoded trailing spaces used to clear old console output.
- After: Informative empty state text shown to new players; smooth and precise line clearing using `ERASE_LINE` macro.
♿ **Accessibility**: Clarifies the primary goal of the CLI application immediately upon first launch, establishing a clear intent for the interface.

---
*PR created automatically by Jules for task [17297837394802696896](https://jules.google.com/task/17297837394802696896) started by @EiJackGH*