### PR TITLE
🎨 Palette: Add empty state for new players

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-10-24 - Encouraging Empty States in CLI
+**Learning:** In terminal applications, hiding UI elements when there is no data (like a high score of 0) creates an ambiguous state for new users. Providing explicit, encouraging empty states clarifies the system state and improves onboarding.
+**Action:** Always provide encouraging empty states for data or achievements rather than hiding the UI element.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**💡 What:**
Added an explicit, encouraging empty state for the "Personal Best" highscore display in the CLI game. Instead of hiding the section when the high score is 0, it now shows: "Personal Best: None yet! Go set a record!".

**🎯 Why:**
Hiding UI elements when data is empty creates an ambiguous and potentially confusing experience for new users onboarding into the application. Providing clear, encouraging empty states clarifies the system state and gives the user a call to action.

**📸 Before/After:**
*Before:*
```
==========================
      SPEED CLICKER
==========================
Controls:
 [h] Toggle Hard Mode (10x Speed!)
 [q] Quit Game
 [Any key] Click!
```

*After:*
```
==========================
      SPEED CLICKER
==========================
 Personal Best: None yet! Go set a record!

Controls:
 [h] Toggle Hard Mode (10x Speed!)
 [q] Quit Game
 [Any key] Click!
```

**♿ Accessibility:**
Improves cognitive accessibility by clearly conveying the state of the system ("you have no high score yet") rather than leaving it to the user's assumption through omission.

---
*PR created automatically by Jules for task [15574569718411886942](https://jules.google.com/task/15574569718411886942) started by @EiJackGH*