### PR TITLE
🎨 Palette: Add empty state for personal best score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-30 - Empty States for Achievements
+**Learning:** Hiding achievement elements (like high scores) when they are zero or empty removes a key onboarding hook. Providing an explicit, encouraging empty state clarifies what the user is working towards and improves engagement for first-time users.
+**Action:** Always provide explicit empty states for data or achievements rather than hiding the UI element.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
- **What:** Added an explicit "None yet! Set a record!" empty state for the personal best display when the high score is 0.
- **Why:** Previously, the high score display was hidden entirely for first-time players. Adding an explicit empty state clarifies the game's goal and encourages new users to play.
- **Before/After:** Before, nothing was displayed. After, an encouraging message is shown.
- **Accessibility:** Improves cognitive accessibility by clearly stating the objective rather than relying on implied absence.

---
*PR created automatically by Jules for task [12715763142377225400](https://jules.google.com/task/12715763142377225400) started by @EiJackGH*