### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-30 - Explicit Empty States in CLI
+**Learning:** In terminal applications, users can be confused if an expected UI element (like a high score) is entirely absent. Hiding the element when data is missing can make the interface feel broken or incomplete. Providing an explicit, encouraging empty state clarifies the system state and improves onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: None yet! Go set a record!\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Replaced the hidden high score state with an explicit empty state ("None yet! Go set a record!") when the user has no existing high score.
🎯 Why: In terminal applications, users can be confused if an expected UI element is entirely absent. Providing an explicit, encouraging empty state clarifies the system state, improves onboarding, and prevents the interface from feeling broken or incomplete.
📸 Before/After: 
  Before: [Speed Clicker]
          Controls: ...
  After:  [Speed Clicker]
          Personal Best: None yet! Go set a record!
          Controls: ...
♿ Accessibility: N/A - text clarity improvement.

---
*PR created automatically by Jules for task [1782947101465930121](https://jules.google.com/task/1782947101465930121) started by @EiJackGH*