### PR TITLE
🎨 Palette: Improve score readability and HUD polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-01-24 - Robust Terminal Line Clearing
+**Learning:** Using manual space padding to clear previous terminal output (e.g., when using \r) is fragile and can leave "ghost" characters if the new line is shorter than the old one. The ANSI escape sequence \033[K (Erase in Line) is a much more robust and cleaner solution.
+**Action:** Use a CLR_EOL macro (\033[K) whenever updating terminal lines in-place to ensure a clean visual state.
+
+## 2025-01-24 - Large Number Readability in CLI
+**Learning:** In fast-paced games where scores can reach high magnitudes, raw numbers become difficult to parse at a glance. Thousands separators (commas) provide immediate visual grouping that significantly reduces cognitive load for the player.
+**Action:** Always format large numeric values with thousands separators in the HUD and game summaries.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -50,6 +51,16 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +152,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +166,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
This PR introduces several micro-UX improvements to the "Speed Clicker" terminal game to enhance readability and visual polish.

💡 **What**: 
- Added a `formatWithCommas` helper to format scores with thousands separators (e.g., `1,000,000` instead of `1000000`).
- Implemented the `CLR_EOL` macro (`\033[K`) to replace fragile space-padding for line updates.
- Standardized HUD styling by applying consistent colors to both labels and values.

🎯 **Why**: 
- Large numbers are difficult to read at a glance in a fast-paced game; commas provide immediate visual grouping.
- Manual space padding can leave visual artifacts if the line length fluctuates; `CLR_EOL` ensures a clean terminal state.
- Consistent color coding helps users quickly distinguish between different HUD elements.

♿ **Accessibility**: 
- Improved visual contrast and information hierarchy through consistent color usage and formatted numeric data.

---
*PR created automatically by Jules for task [6643702494115697253](https://jules.google.com/task/6643702494115697253) started by @aidasofialily-cmd*