### PR TITLE
🎨 Palette: Add empty state for Personal Best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-05-25 - Empty States in CLI Applications
+**Learning:** In terminal applications, displaying a blank space or skipping output when data (like a high score) is missing can leave users confused about the system state. Providing an explicit, encouraging empty state (e.g., "None yet! Go set a record!") clarifies that the system is working and gently onboards the user.
+**Action:** Always provide explicit empty states for data-driven UI elements in CLI applications, rather than simply hiding them when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
- What: Added an explicit "None yet! Go set a record!" message when the user has no previous high score, instead of simply hiding the Personal Best display line.
- Why: It provides a friendlier onboarding experience for new users, removing ambiguity about whether the game tracks scores.
- Accessibility: Provides clear, immediate text feedback to the user regarding their achievement state, improving cognitive accessibility.

---
*PR created automatically by Jules for task [17094143463608199038](https://jules.google.com/task/17094143463608199038) started by @EiJackGH*