### PR TITLE
🎨 Palette: Add empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-06-01 - Explicit Empty States for Achievements
+**Learning:** Hiding UI elements like "Personal Best" when data is missing creates an ambiguous system state and misses an opportunity for user onboarding.
+**Action:** Provide explicit, encouraging empty states (e.g., "0 (Play to set a record!)") to clarify system state and encourage user engagement.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "0" << CLR_RESET << " (Play to set a record!)\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state to the high score display. Instead of hiding the "Personal Best" element when the high score is 0, the system now displays "Personal Best: 0 (Play to set a record!)".

🎯 **Why:** Hiding UI elements when data is missing creates an ambiguous system state and misses an opportunity for user onboarding. Providing an explicit empty state clarifies the situation and encourages user engagement.

📸 **Before/After:**
*   **Before:** (High score hidden completely if 0)
*   **After:** `Personal Best: 0 (Play to set a record!)`

♿ **Accessibility:** This change makes the UI more predictable and provides clearer feedback on the current state of the application for first-time users.

---
*PR created automatically by Jules for task [6454883003447903094](https://jules.google.com/task/6454883003447903094) started by @EiJackGH*