### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-02 - Empty States in CLI Applications
+**Learning:** In terminal applications, displaying an empty or non-existent achievement status (like a missing high score) simply by omitting the UI element leaves the user wondering if the feature exists or is broken.
+**Action:** Always provide explicit, encouraging empty states for data or achievements to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state message for the "Personal Best" section in the CLI when no high score exists.
🎯 **Why:** Hiding the "Personal Best" section completely when there is no score leaves the user wondering if the feature exists or is broken. Providing an explicit, encouraging empty state clarifies the system state and improves user onboarding.
📸 **Before/After:**
*Before:*
```
==========================
      SPEED CLICKER
==========================
Controls:
 [h] Toggle Hard Mode (10x Speed!)
...
```
*After:*
```
==========================
      SPEED CLICKER
==========================
 Personal Best: None yet! Go set a record!

Controls:
 [h] Toggle Hard Mode (10x Speed!)
...
```
♿ **Accessibility:** Improves cognitive accessibility by explicitly confirming system state to the user rather than relying on implied absence of UI elements.

---
*PR created automatically by Jules for task [4923508091266530102](https://jules.google.com/task/4923508091266530102) started by @EiJackGH*