### PR TITLE
🎨 Palette: Improve score readability and HUD polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-03-05 - Robust CLI HUD Updates
+**Learning:** Utilizing the ANSI 'Erase in Line' escape sequence (`\033[K`) is a more robust UX practice than space padding for in-place terminal updates, as it guarantees the removal of all characters from the previous line regardless of length changes (e.g., when a score jumps from 999 to 1,000).
+**Action:** Use a `CLR_EOL` macro (defined as `\033[K`) at the end of carriage-returned (`\r`) lines to ensure clean UI refreshes in CLI applications.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -30,6 +31,16 @@ void restore_terminal(int signum) {
     const char msg[] = "\033[0m\033[?25h\n\nGame interrupted. Terminal settings restored.\n";
     write(STDOUT_FILENO, msg, sizeof(msg) - 1);
     _exit(signum);
+}
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
 }
 
 long long load_highscore() {
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +152,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +166,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
### 💡 What:
Implemented a set of micro-UX improvements focused on numeric readability and visual feedback in the CLI environment.

- **Thousands Separators:** Added a `formatWithCommas` utility to all score displays (initial PB, live HUD, and final summary).
- **Robust HUD Updates:** Introduced a `CLR_EOL` macro (ANSI `\033[K`) to replace manual space-padding, ensuring clean line refreshes as numeric values change length.
- **Visual Polish:** Colorized the "Score:" and "High:" labels consistently with their values and added a celebration color (Bold Green) to the "NEW BEST!" notification.

### 🎯 Why:
Large numbers are difficult to read at a glance without separators. Additionally, terminal HUDs often suffer from "ghost characters" when a line becomes shorter than its previous state; using `CLR_EOL` guarantees a clean slate for every update.

### ♿ Accessibility:
Consistent bold cyan styling for score-related information creates a clear visual hierarchy, making it easier for users to track progress and achievements during fast-paced gameplay.

---
*PR created automatically by Jules for task [5617294944049430303](https://jules.google.com/task/5617294944049430303) started by @aidasofialily-cmd*