### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-03 - Empty States as Onboarding
+**Learning:** In CLI applications, omitting an element (like a high score) when its value is zero or missing can leave new users confused about the system's capabilities. Providing an explicit, encouraging empty state clarifies the interface and serves as an implicit onboarding tool.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
### 💡 What
Added an explicit, encouraging empty state to the "Personal Best" high score display. When a user first opens the game and has no high score, instead of seeing nothing, they see: "None yet! Go set a record!".

### 🎯 Why
In CLI applications, omitting an element when its value is zero or missing can leave new users confused about the system's capabilities. Providing an explicit empty state clarifies the interface, serves as an implicit onboarding tool, and encourages initial engagement.

### 📸 Before/After
**Before:**
(High score section is completely hidden if score is 0)
```
==========================
      SPEED CLICKER
==========================
Controls:
 [h] Toggle Hard Mode (10x Speed!)
...
```

**After:**
(Explicit encouraging message is shown)
```
==========================
      SPEED CLICKER
==========================
 Personal Best: None yet! Go set a record!

Controls:
 [h] Toggle Hard Mode (10x Speed!)
...
```

### ♿ Accessibility
This change improves cognitive accessibility by explicitly stating the absence of data rather than relying on the user to deduce it from missing information. It reduces the cognitive load required to understand the game's progression system.

---
*PR created automatically by Jules for task [6989553650711704561](https://jules.google.com/task/6989553650711704561) started by @EiJackGH*