### PR TITLE
🎨 Palette: Add encouraging empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-04 - Encouraging Empty States in CLI
+**Learning:** Hiding UI elements like high scores when they are zero or empty leaves users guessing about the system state. Providing an explicit, encouraging empty state clarifies the system's capabilities and improves user onboarding.
+**Action:** Always provide an explicit, encouraging empty state instead of hiding elements when data is missing or zero.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " " << CLR_NORM << "No personal best yet. Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
Added an encouraging empty state message when the user has not yet set a high score.

**What**:
Instead of just displaying nothing when the highscore is 0, the game now displays a message saying "No personal best yet. Play to set a record!".

**Why**:
Hiding UI elements when data is zero leaves users guessing. An explicit, encouraging message clarifies the system capabilities and improves onboarding.

**Before/After**:
- Before: If highscore == 0, the "Personal Best" section was just hidden.
- After: If highscore == 0, the "Personal Best" section shows a prompt to set a record.

**Accessibility**:
Clarifies the system state to users immediately upon startup rather than relying on absence of information.

---
*PR created automatically by Jules for task [13812756041610742927](https://jules.google.com/task/13812756041610742927) started by @EiJackGH*