### PR TITLE
🎨 Palette: Add welcoming empty state for missing highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-05-24 - Missing empty state for scores
+**Learning:** In CLI games with high scores, a lack of an empty state when the score is zero or undefined can leave users confused or unengaged at startup.
+**Action:** Add a welcoming empty state for highscores (e.g., "None yet! Start clicking!") instead of hiding the score display entirely. This makes the UI more approachable.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Start clicking!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added a welcoming empty state ("None yet! Start clicking!") that displays when the user's high score is zero.
🎯 Why: In CLI games with high scores, a lack of an empty state when the score is zero or undefined can leave users confused or unengaged at startup. This makes the UI more approachable for first-time players.
📸 Before/After: Before, if the high score was 0, nothing was displayed. Now, it displays: "Personal Best: None yet! Start clicking!"
♿ Accessibility: Improves the cognitive accessibility and user onboarding by providing explicit feedback about the system's state (that a highscore feature exists but has no data yet).

---
*PR created automatically by Jules for task [8798106718540815852](https://jules.google.com/task/8798106718540815852) started by @EiJackGH*