### PR TITLE
🎨 Palette: Improve score readability and terminal UI polish

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #define CLR_HARD  "\033[1;31m"
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
+#define CLR_EOL   "\033[K"
 #define CLR_RESET "\033[0m"
 
 struct termios oldt;
@@ -30,6 +31,17 @@ void restore_terminal(int signum) {
     const char msg[] = "\033[0m\033[?25h\n\nGame interrupted. Terminal settings restored.\n";
     write(STDOUT_FILENO, msg, sizeof(msg) - 1);
     _exit(signum);
+}
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = static_cast<int>(s.length());
+    int insertPosition = n - 3;
+    while (insertPosition > (value < 0 ? 1 : 0)) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
 }
 
 long long load_highscore() {
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,12 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best! 🥳" << CLR_RESET << "\n";
+        if (initialHighscore > 0) {
+            std::cout << "You beat your previous record of " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << "!\n";
+        }
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
💡 **What:**
- Added thousands separators (e.g., `1,000`) to all score displays (Personal Best, active HUD, and Final Score) using a new `formatWithCommas` helper.
- Switched from space-padding to the ANSI "Erase in Line" (`\033[K`) sequence for cleaner terminal updates during the countdown and gameplay.
- Added a celebration message on the game-over screen that shows the player's previous record when they set a new personal best.
- Standardized color usage for "NEW BEST!" and congratulations messages.

🎯 **Why:**
- Large numeric values in clicker games become difficult to parse at a glance without separators.
- Manual space-padding was brittle and left "ghost characters" when switching between strings of different lengths (e.g., "Starting in 1..." to "GO!").
- Providing context for achievements (showing the old record) makes the victory feel more meaningful.

♿ **Accessibility:**
- Improved visual clarity of high-stakes numeric information.
- Enhanced feedback through consistent, high-contrast terminal colors for interactive and status elements.

---
*PR created automatically by Jules for task [10914109993269564248](https://jules.google.com/task/10914109993269564248) started by @aidasofialily-cmd*