### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-06-06 - Explicit Empty States in CLI
+**Learning:** In terminal applications, hiding UI elements when there's no data (like a score of 0) creates an ambiguous state where users might not realize the feature exists. Providing an explicit, encouraging empty state clarifies the system state and improves user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state for the "Personal Best" score. If the high score is 0, the game now displays an encouraging message ("None yet! Play to set a record!") instead of hiding the score element entirely.

🎯 **Why:** Hiding UI elements when there's no data creates an ambiguous state where new users might not realize the feature exists. Providing an explicit empty state clarifies the system state and improves onboarding.

📸 **Before/After:**
- Before: The "Personal Best" text was completely hidden if the score was 0.
- After: The text "Personal Best: None yet! Play to set a record!" is displayed if the score is 0.

♿ **Accessibility:** This improves cognitive accessibility by making the system state explicit and discoverable without requiring users to infer missing features.

---
*PR created automatically by Jules for task [12409649881743533324](https://jules.google.com/task/12409649881743533324) started by @EiJackGH*