### PR TITLE
🎨 Palette: Add explicit empty state for Personal Best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-24 - Empty States in CLI
+**Learning:** Hiding UI elements when data is empty (like a high score) leaves new users uncertain about the system's capabilities.
+**Action:** Always provide explicit, encouraging empty states for achievements or data to clarify system state and improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state message ("None yet! Set a record!") for the Personal Best score on first launch.
🎯 Why: Hiding the high score entirely when it's zero leaves new users uncertain about the game's achievement system. An explicit empty state provides a clear onboarding goal and clarifies the system state.
📸 Before/After: N/A (CLI application)
♿ Accessibility: Improves cognitive accessibility by explicitly stating the current state instead of relying on the absence of information.

---
*PR created automatically by Jules for task [13890090117203934421](https://jules.google.com/task/13890090117203934421) started by @EiJackGH*