### PR TITLE
🎨 Palette: Improve score readability and terminal UI polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-07 - Robust Terminal UI Updates with CLR_EOL
+**Learning:** Utilizing the ANSI 'Erase in Line' escape sequence (`\033[K`) is a more robust UX practice than space padding for in-place terminal updates. It guarantees the removal of all characters from the previous line regardless of length changes, preventing "ghost" artifacts.
+**Action:** Use a `CLR_EOL` macro to clear lines during volatile terminal updates like countdowns or live HUDs.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,19 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = static_cast<int>(s.length());
+    int insertPosition = (value < 0) ? 1 : 0;
+    for (int i = n - 3; i > insertPosition; i -= 3) {
+        s.insert(i, ",");
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -108,7 +119,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_EOL << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +152,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +165,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
💡 **What:** This PR introduces several micro-UX improvements to the Speed Clicker game:
- Thousands separators for all score displays (Header, Live HUD, Final Score).
- Robust terminal line clearing using the `CLR_EOL` (\033[K) escape sequence, replacing brittle manual space padding.
- Enhanced achievement feedback by displaying the previous personal best alongside a new record.

🎯 **Why:** 
- Large numeric values (e.g., 10000 vs 10,000) are significantly easier to parse with separators.
- ANSI line clearing prevents "ghost characters" from appearing when the output length decreases.
- Providing context for new achievements (the previous record) increases the player's sense of progression.

♿ **Accessibility:**
- Improved visual readability of scores.
- Consistent color coding (`CLR_SCORE`) for both labels and values in the HUD.

---
*PR created automatically by Jules for task [1011546915508951197](https://jules.google.com/task/1011546915508951197) started by @aidasofialily-cmd*