### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-24 - Explicit Empty States
+**Learning:** Hiding UI elements like highscores when empty can make the system state unclear to new users.
+**Action:** Always provide explicit, encouraging empty states for data or achievements to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "0" << CLR_RESET << " (No record yet. Go set one!)\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
* 💡 What: Added an encouraging empty state message when the highscore is 0.
* 🎯 Why: Hiding UI elements like highscores when empty can make the system state unclear to new users and feels less welcoming. An explicit empty state improves user onboarding.
* 📸 Before/After: Before, no highscore line was shown if the score was 0. After, it shows a 0 highscore with a motivational prompt.
* ♿ Accessibility: Improves cognitive accessibility by clearly defining the UI state for first-time users.

---
*PR created automatically by Jules for task [9397709620393123362](https://jules.google.com/task/9397709620393123362) started by @EiJackGH*