### PR TITLE
🎨 Palette: Improve score readability and achievement feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-08 - Robust In-place Terminal Updates
+**Learning:** Using trailing spaces to "clear" previous terminal output is fragile and often leads to "ghost" characters if the new string is shorter than the old one. The ANSI 'Erase in Line' sequence (`\033[K`) provides a much cleaner and more reliable way to ensure the terminal line is cleared from the cursor to the end.
+**Action:** Always use the `CLR_EOL` macro (`\033[K`) when performing in-place terminal updates with carriage returns (`\r`) to ensure a clean UI.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #define CLR_HARD  "\033[1;31m"
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
+#define CLR_EOL   "\033[K"
 #define CLR_RESET "\033[0m"
 
 struct termios oldt;
@@ -50,6 +51,17 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > 0) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    if (value < 0) s = "-" + s;
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << " | High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best (previously " << formatWithCommas(initialHighscore) << ")!\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
💡 **What:**
- Added a `formatWithCommas` utility to display thousands separators for scores.
- Replaced fragile space-padding with the ANSI "Erase in Line" sequence (`CLR_EOL`).
- Enhanced the HUD with consistent `CLR_SCORE` styling and fixed color bleeding between status indicators.
- Updated the game-over screen to display the previous personal best when a new record is achieved.

🎯 **Why:**
- Large numeric values (common in clicker games) are difficult to parse at a glance without separators.
- ANSI `\033[K` is more robust than space-padding for clearing terminal lines of variable length.
- Showing the previous record provides immediate context for the player's achievement, increasing delight.

♿ **Accessibility:**
- Improved visual separation of labels and values in the terminal HUD using consistent bold colors.
- Ensured status messages like "NEW BEST!" have clear color boundaries to prevent visual confusion.

---
*PR created automatically by Jules for task [5584593479430040483](https://jules.google.com/task/5584593479430040483) started by @aidasofialily-cmd*