### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Explicit Empty States for Onboarding
+**Learning:** Hiding UI elements (like a high score) when they are empty or zero can leave new users confused about the application's features. Explicit, encouraging empty states help clarify the system's capabilities and provide immediate goals for the user.
+**Action:** Always provide explicit empty states for data or achievements rather than hiding them, offering helpful guidance or a call-to-action to improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet. Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**💡 What**: 
Added an explicit "None yet. Set a record!" message for the high score when the user's score is 0.

**🎯 Why**: 
Previously, if the high score was 0, the `Personal Best:` line was completely hidden. Hiding UI elements like a high score when they are empty or zero can leave new users confused about the application's features. Explicit, encouraging empty states help clarify the system's capabilities and provide immediate goals for the user.

**📸 Before/After**:
*Before:* The UI only displayed the game title and controls when opening the game for the first time.
*After:* The UI displays `Personal Best: None yet. Set a record!` immediately under the game title when opening the game for the first time.

**♿ Accessibility**:
Improves cognitive accessibility and onboarding by making system capabilities (high score tracking) explicit rather than implied or hidden.

---
*PR created automatically by Jules for task [3943206111900137352](https://jules.google.com/task/3943206111900137352) started by @EiJackGH*