### PR TITLE
🎨 Palette: Enhance score readability and terminal polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-09 - Robust In-place Terminal Updates
+**Learning:** Using space padding to clear previous terminal lines during in-place updates (carriage return) is brittle and often leaves "ghost" characters if the new line is shorter. The ANSI 'Erase in Line' escape sequence (`\033[K`) is a much more robust solution as it clears the entire remainder of the line regardless of content length.
+**Action:** Use a `CLR_EOL` macro (defined as `\033[K`) for all in-place terminal updates to ensure a clean and professional UI transition.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0 ? 1 : 0);
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "..." << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_EOL << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | "
+                      << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! You beat your old record of " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << "!\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 🎨 Palette: Enhance score readability and terminal polish

This PR introduces several micro-UX improvements to the Speed Clicker game to enhance readability, visual consistency, and terminal interaction quality.

#### 💡 What:
- **Score Formatting:** Added a `formatWithCommas` helper function to apply thousands separators to all score displays (Personal Best, live HUD, Final Score).
- **Terminal Polish:** Introduced the `CLR_EOL` (Erase in Line) ANSI sequence to cleanly update the HUD and countdowns, replacing brittle space padding.
- **Visual Consistency:** Styled the "High:" label in the live HUD to match the "Score:" label's color (`CLR_SCORE`).
- **Contextual Achievement:** Enhanced the game-over screen to explicitly mention the previous record when a new personal best is achieved.

#### 🎯 Why:
- Large numbers are difficult to read at a glance without separators.
- In-place terminal updates using `\r` can leave trailing "ghost" characters if the new line is shorter than the previous one; `CLR_EOL` fixes this.
- Providing the previous record on the game-over screen gives the user immediate context for their achievement.

#### ♿ Accessibility:
- Improved visual structure and clarity of numeric information through formatting and consistent color-coding.

#### 📸 Before/After:
- **Before:** `Score: 12345 | High: 12345 [NORMAL MODE]`
- **After:** `Score: 12,345 | High: 12,345 [NORMAL MODE]` (with consistent coloring)

---
*PR created automatically by Jules for task [16742528103097323964](https://jules.google.com/task/16742528103097323964) started by @aidasofialily-cmd*