### PR TITLE
🎨 Palette: Add explicit empty states and eliminate hardcoded UI paddings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-05-24 - Empty States and Terminal Artifacts
+**Learning:** In terminal applications, relying on spaced padding for clearing line content is error-prone. Providing an empty state "None yet!" is encouraging for new players rather than just hiding the High Score string.
+**Action:** Use empty states to guide users when no achievements are present, and use ANSI ERASE_LINE to erase terminal buffers dynamically and reliably.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -78,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +97,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +111,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +144,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 What: Introduced a "None yet! Set a record!" empty state for first-time players. Replaced hardcoded spacing with terminal ERASE_LINE ANSI commands.
🎯 Why: It improves the onboarding feeling and prevents visual trailing artifacts during gameplay loops.
📸 Before/After: Visual artifacts removed.
♿ Accessibility: More intuitive feedback loop with standard ANSI commands.

---
*PR created automatically by Jules for task [17083709152231075170](https://jules.google.com/task/17083709152231075170) started by @EiJackGH*