### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-24 - Explicit Empty States for Achievements
+**Learning:** Hiding achievement metrics (like high scores) when they are zero can leave users confused about the application's capabilities.
+**Action:** Always provide an explicit, encouraging empty state (e.g., "None yet! Start clicking!") rather than hiding the element entirely.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Start clicking!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**💡 What:** 
Added an explicit `else` branch to the high score display logic in `src/main.cpp`.

**🎯 Why:** 
Previously, if the user had no high score (score was 0), the UI simply hid the "Personal Best" element. This leaves first-time users confused about the game's capabilities or achievements. Adding an explicit, encouraging empty state ("None yet! Start clicking!") improves onboarding.

**📸 Before/After:** 
*Before:* [Blank space under title]
*After:*  `Personal Best: None yet! Start clicking!`

**♿ Accessibility/UX:** 
Provides explicit feedback on the system's state rather than relying on the absence of elements, which is a known UX anti-pattern for onboarding.

---
*PR created automatically by Jules for task [4868293321966461844](https://jules.google.com/task/4868293321966461844) started by @EiJackGH*