### PR TITLE
🎨 Palette: Improve score readability and HUD polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Robust Line Clearing in Terminal UIs
+**Learning:** Using the ANSI escape sequence `\033[K` (Erase in Line) is superior to space-padding when updating lines with `\r`. It ensures that characters from longer previous lines are completely removed, preventing "ghost" characters and visual artifacts.
+**Action:** Always define and use a `CLR_EOL` macro or equivalent when performing in-place terminal updates to ensure a clean UI transition.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include <cmath>
 
 // Color and formatting macros for terminal output
 #define RESET     "\033[0m"
@@ -21,8 +22,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > 0) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    if (value < 0) s.insert(0, "-");
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +90,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +107,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +121,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +154,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << CLR_RESET << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +168,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best!" << CLR_RESET << " (Previous best: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What:
This PR enhances the terminal UI of SPEED CLICKER with several micro-UX improvements:
- **Numeric Formatting:** Added a `formatWithCommas` helper to display scores and high scores with thousands separators (e.g., `1,000` instead of `1000`).
- **Robust Line Clearing:** Replaced space-padding with the ANSI `\033[K` (Erase in Line) escape sequence to prevent "ghost" characters during in-place terminal updates.
- **Visual Polish:** Colorized HUD labels ("Score:", "High:") and the "NEW BEST!" achievement indicator for better visual hierarchy.
- **Achievement Context:** The game-over screen now displays the player's previous personal best alongside their new score when a record is broken.

### 🎯 Why:
- Reading large, unformatted numbers is cognitively taxing during fast-paced gameplay.
- Terminal artifacts (leftover characters from previous lines) made the UI feel unpolished.
- Providing context for new records (showing the previous best) increases the player's sense of achievement.

### ♿ Accessibility:
- Improved visual cues and color-coding help users quickly distinguish between different types of information in the HUD.
- Consistent formatting across all screens (start, HUD, final summary) provides a more predictable and accessible experience.

---
*PR created automatically by Jules for task [13495191780902260946](https://jules.google.com/task/13495191780902260946) started by @aidasofialily-cmd*