### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-25 - Encouraging Empty States in CLI
+**Learning:** Hiding UI elements like a high score when empty can leave users confused about their progress or what to achieve. Providing an explicit, encouraging empty state clarifies the system state and improves user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements in CLI applications rather than hiding the element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "0 (No record yet! Start clicking!)" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit message when the user's high score is 0.
🎯 Why: Hiding UI elements like a high score when empty can leave users confused about their progress or what to achieve. Providing an explicit, encouraging empty state clarifies the system state and improves user onboarding.
📸 Before/After: Before, if the high score was 0, nothing was displayed under the title. After, it displays "Personal Best: 0 (No record yet! Start clicking!)".
♿ Accessibility: Improves cognitive accessibility by explicitly stating the current progress instead of relying on the absence of information.

---
*PR created automatically by Jules for task [10636982021210766828](https://jules.google.com/task/10636982021210766828) started by @EiJackGH*