### PR TITLE
🎨 Palette: [Add empty state for highscore]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2026-06-13 - Encouraging Empty States in CLI
+**Learning:** Providing explicit, encouraging empty states for data or achievements clarifies the system state for first-time users and improves onboarding, compared to just hiding the UI element when empty.
+**Action:** Always provide an explicit empty state instead of hiding UI elements for initial states.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit `else` branch to the `highscore > 0` check on the startup screen. When the highscore is 0, it now displays "None yet! Set a record!".
🎯 **Why:** To improve onboarding. Previously, if no high score existed, the UI element was simply omitted. Explicit empty states are much more helpful for first-time players to understand the goals and state of the application.
📸 **Before/After:** Before: (Nothing displayed). After: `Personal Best: None yet! Set a record!`.
♿ **Accessibility:** This UX change provides clearer textual feedback to users regarding application state.

---
*PR created automatically by Jules for task [15131228931115943991](https://jules.google.com/task/15131228931115943991) started by @EiJackGH*