### PR TITLE
🎨 Palette: Terminal UX polish with score formatting and line clearing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Robust Terminal UI Updates with CLR_EOL
+**Learning:** In terminal applications that use carriage returns (\r) for in-place line updates, simply overwriting the line with new text can leave "ghost" characters if the new string is shorter than the previous one. Using the ANSI 'Erase in Line' escape sequence (\033[K) at the end of every update ensures a clean, artifact-free interface without needing complex space-padding logic.
+**Action:** Implement a CLR_EOL macro and append it to volatile terminal output lines to guarantee visual consistency.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > 0) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    if (value < 0) s.insert(0, "-");
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << CLR_RESET << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_NORM " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +167,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Implemented a suite of terminal UX improvements for the Speed Clicker game:
1.  **Score Readability:** Added a `formatWithCommas` helper to display scores with thousands separators (e.g., `1,234,567`).
2.  **Visual Stability:** Integrated the `CLR_EOL` (`\033[K`) ANSI sequence to ensure that in-place line updates (using `\r`) are always clean and free of "ghost" characters from previous, longer lines.
3.  **UI Consistency:** Standardized the use of `CLR_SCORE` (Bold Cyan) for both labels and values in the HUD.
4.  **Achievement Feedback:** Applied `CLR_NORM` (Bold Green) to the "NEW BEST!" message to make the milestone more visually rewarding.

### 🎯 Why: The user problem it solves
- **Readability:** As scores grow, large numbers become difficult to parse at a glance in a fast-paced game. Thousands separators provide immediate clarity.
- **Visual Artifacts:** Without explicit line clearing, shorter HUD updates leave behind trailing characters from longer ones, making the UI look broken.
- **Visual Hierarchy:** Inconsistent coloring between labels and values made the HUD harder to scan.

### ♿ Accessibility: Any a11y improvements made
- Improved color contrast and semantic coloring: Using Bold Green (`CLR_NORM`) for achievements and Bold Cyan (`CLR_SCORE`) for data points helps users quickly distinguish between gameplay status and numeric progress.
- Enhanced clarity for large numbers through standard decimal grouping.

---
*PR created automatically by Jules for task [387977227336004681](https://jules.google.com/task/387977227336004681) started by @aidasofialily-cmd*