### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2025-01-28 - Explicit Empty States
+**Learning:** Hiding UI elements when data is empty can leave users confused about system state.
+**Action:** Provide explicit, encouraging empty states for data or achievements to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Changed the UI to display "None yet! Go set a record!" when the highscore is 0, instead of hiding the highscore completely.
🎯 Why: Hiding UI elements when data is empty can leave users confused about system state. An explicit empty state provides clarity and encourages engagement, improving onboarding for first-time players.
📸 Before/After: Before, a new player saw no high score information. Now, they see an encouraging message indicating they should play to set one.
♿ Accessibility: Improves cognitive accessibility by explicitly confirming the system state (no score recorded) rather than relying on the user to infer it from missing information.

---
*PR created automatically by Jules for task [9876251712576668846](https://jules.google.com/task/9876251712576668846) started by @EiJackGH*