### PR TITLE
🎨 Palette: Improve score readability and HUD visual polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-14 - Robust CLI Line Clearing and Numeric Readability
+**Learning:** In terminal UIs with carriage-returned (\r) updates, using space-padding to "clear" previous content is brittle and often leaves "ghost" characters. The ANSI "Erase in Line" sequence (\033[K) is the robust solution. Additionally, as numeric values escalate in games, thousands separators are essential for glanceability and readability.
+**Action:** Use a `CLR_EOL` macro (\033[K) for all in-place terminal updates and implement a `formatWithCommas` helper for all large numeric displays.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(std::abs(value));
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > 0) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    if (value < 0) s.insert(0, "-");
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << " | High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_NORM " ✨ NEW BEST! ✨" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_NORM << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")" << CLR_RESET << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 🎨 Palette: Improve score readability and HUD visual polish

This PR introduces several micro-UX improvements to the SPEED CLICKER terminal game to enhance readability, visual polish, and player feedback.

#### 💡 What:
- **Numeric Readability:** Added a `formatWithCommas` helper function to display scores with thousands separators (e.g., `1,000` instead of `1000`).
- **Visual Polish:** Replaced brittle space-padding with the ANSI "Erase in Line" sequence (`\033[K`) for cleaner in-place terminal updates during the countdown and HUD refreshes.
- **Enhanced Achievement Feedback:** The "NEW BEST!" message is now colorized and styled with emojis.
- **Improved Context:** The final score screen now displays the previous personal best alongside the new high score for better achievement context.

#### 🎯 Why:
- Large numbers are difficult to read at a glance without separators.
- Ghost characters from previous lines can clutter the UI if padding isn't perfectly managed; `CLR_EOL` solves this robustly.
- Providing context for new high scores makes achievements feel more meaningful.

#### ♿ Accessibility:
- Improved visual hierarchy in the HUD by consistently colorizing labels and values.
- Clearer status indicators for [HARD MODE] and [NORMAL MODE].

---
*PR created automatically by Jules for task [5551686545529005426](https://jules.google.com/task/5551686545529005426) started by @aidasofialily-cmd*