### PR TITLE
🎨 Palette: Add empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-15 - Explicit Empty States in CLI
+**Learning:** In terminal applications, hiding UI elements when they have no data (like a missing high score on first launch) can leave users confused about what the system state is. Explicit, encouraging empty states (e.g., "None yet! Go set a record!") clarify the system state and improve user onboarding by providing a clear goal.
+**Action:** Always provide explicit, encouraging empty states for data or achievements in CLI applications rather than simply hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
What: Added an explicit "None yet! Go set a record!" message when a user plays for the first time and hasn't set a high score.

Why: Hiding UI elements when they have no data can leave users confused about what the system state is. Explicit, encouraging empty states clarify the system state and improve user onboarding by providing a clear goal.

Before/After: 
Before: The "Personal Best" element was entirely absent on the first run.
After: The element is present with placeholder text: "Personal Best: None yet! Go set a record!"

Accessibility/UX: Improves the first-time user experience (FTUE) by providing a clear goal instead of a missing UI element. Also prevents minor layout shifts when a high score is eventually achieved, as the vertical spacing is now consistent from the first run.

---
*PR created automatically by Jules for task [8388888994152054575](https://jules.google.com/task/8388888994152054575) started by @EiJackGH*