### PR TITLE
🎨 Palette: Add thousands separators to score displays

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,17 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -141,7 +152,7 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
                       << "           " << std::flush;
@@ -154,7 +165,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Implemented a `formatWithCommas` helper function to add thousands separators to numeric values. This function is now used for:
- The "Personal Best" display on the start screen.
- The live "Score" and "High" score in the game HUD.
- The "Final Score" on the game-over screen.

### 🎯 Why: The user problem it solves
As scores grow larger in "Speed Clicker," they become harder to read at a glance. Thousands separators (e.g., `1,250,000` vs `1250000`) significantly improve readability and the overall "tactile" feel of achievement.

### ♿ Accessibility
Improves cognitive accessibility by making large numbers easier to parse and compare.


---
*PR created automatically by Jules for task [2479086845385226970](https://jules.google.com/task/2479086845385226970) started by @aidasofialily-cmd*