### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-16 - Explicit Empty States in CLI
+**Learning:** In terminal applications, it's better UX to explicitly state when an achievement or data is empty (e.g. "Personal Best: None yet!") rather than just hiding the section entirely. It clarifies the system state and gives new users an immediate goal to strive for.
+**Action:** Always provide explicit, encouraging empty states for data or achievements to clarify the UI and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit "None yet!" message when the user has no high score.
🎯 Why: To improve onboarding and give new users an immediate goal to strive for instead of just hiding the high score section.
📸 Before/After: N/A
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [1839000040065039253](https://jules.google.com/task/1839000040065039253) started by @EiJackGH*