### PR TITLE
🎨 Palette: Enhance score readability and terminal robustness

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Robust Line Clearing in CLI
+**Learning:** Using manual space-padding to clear previous terminal output is fragile and often leads to "ghost characters" if the new content is shorter. The ANSI "Erase in Line" escape sequence (\033[K), implemented as a CLR_EOL macro, provides a robust and flicker-free way to ensure the terminal line is perfectly cleared from the cursor position to the end.
+**Action:** Always prefer CLR_EOL over manual space-padding for in-place terminal updates (like HUDs or countdowns) to ensure visual stability.
+
+## 2024-05-24 - Numeric Legibility in High-Score Games
+**Learning:** In games where scores can reach high magnitudes, raw numbers become difficult to parse at a glance. Implementing thousands separators (e.g., 1,000,000) significantly reduces cognitive load and improves the "delight" factor by making achievements feel more substantial and readable.
+**Action:** Use a formatting helper like formatWithCommas for all large numeric displays in CLI applications to enhance data accessibility.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -50,6 +51,17 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << CLR_RESET << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << CLR_EOL << CLR_RESET << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +167,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
💡 What:
- Added `formatWithCommas` helper to display scores with thousands separators (e.g., "1,000" instead of "1000").
- Introduced `CLR_EOL` macro (\033[K) for robust terminal line clearing, replacing manual space-padding.
- Improved HUD visual balance by applying `CLR_SCORE` to the "High Score" label.
- Added `CLR_RESET` to the end of volatile HUD lines to prevent color bleed.

🎯 Why:
- Thousands separators make large scores much easier to read at a glance, improving the game's sense of progression.
- `CLR_EOL` prevents "ghost characters" from previous longer lines, ensuring a cleaner and more professional-looking UI during rapid updates.

♿ Accessibility:
- Improved visual contrast and consistency in the HUD.
- Better data legibility through numeric formatting.

---
*PR created automatically by Jules for task [16885298493882002832](https://jules.google.com/task/16885298493882002832) started by @aidasofialily-cmd*