### PR TITLE
🎨 Palette: [Improve dynamic line clearing and zero-state UX]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-17 - Encouraging Empty States in CLI
+**Learning:** In CLI applications, a blank or hidden interface element when data is missing (e.g., hiding the High Score when it's 0) provides no guidance to the user. Explicitly showing an encouraging "Empty State" (e.g., "None yet! Go set one!") is much more welcoming and clarifying for first-time users.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.
+
+## 2024-06-17 - Erasing Terminal Lines with ANSI
+**Learning:** Hardcoding padding spaces (e.g., `GO!             `) to overwrite previous dynamic terminal lines leads to maintenance issues and visual artifacts if the new string is shorter than expected.
+**Action:** Use the ANSI escape sequence `\033[K` (Erase in Line) immediately after a carriage return `\r` to cleanly clear the line before writing new content, preventing trailing text artifacts.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +96,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r\033[KStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +110,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +143,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
This commit implements a micro-UX improvement for the Speed Clicker CLI game.

💡 What: Replaced hardcoded whitespace padding with the ANSI escape sequence `\033[K` (Erase in Line) during dynamic `\r` line updates, and added an encouraging text state when the high score is 0.

🎯 Why: Hardcoded spaces are fragile and can leave visual artifacts if the new text string is unexpectedly short. The `\033[K` sequence guarantees a clean line before drawing. Additionally, showing "None yet! Go set one!" is a far better new user experience than simply hiding the High Score element.

📸 Before/After:
Before:
- High score was completely hidden on first play.
- Output text like `GO!             ` used spaces to clear the old `Starting in X...` line.

After:
- First-time players see: `Personal Best: None yet! Go set one!`
- Output text uses `\r\033[KGO!` to cleanly clear the line first.

♿ Accessibility: Ensures that dynamic text updates in the terminal are rendered cleanly without visual stutter or trailing artifacts, providing a smoother experience for users relying on terminal screen readers or with cognitive visual sensitivities. The empty state provides explicit cognitive guidance rather than ambiguous silence.

---
*PR created automatically by Jules for task [7596036197219589482](https://jules.google.com/task/7596036197219589482) started by @EiJackGH*