### PR TITLE
🎨 Palette: Improve score readability and UI polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-23 - Robust Line Clearing in CLI
+**Learning:** Using space-padding to clear previous terminal content is brittle and can lead to "ghost" characters if the previous line was longer. The ANSI escape sequence \033[K (Erase in Line) provides a robust way to clear from the cursor to the end of the line, ensuring a clean UI state.
+**Action:** Use a CLR_EOL macro with \033[K for all in-place terminal updates in CLI applications.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,9 +20,21 @@
 #define CLR_HARD  "\033[1;31m"
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
+#define CLR_EOL   "\033[K"
 #define CLR_RESET "\033[0m"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_EOL << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << " | High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_CTRL " ✨ NEW BEST! ✨" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What
This PR introduces several micro-UX improvements to Speed Clicker:
- **Number Formatting**: Implemented `formatWithCommas` to add thousands separators to all score displays (initial PB, live score, HUD high score, and final score).
- **Robust UI Updates**: Defined `CLR_EOL` (`\033[K`) to replace manual space-padding. This ensures the terminal line is cleanly wiped regardless of previous content length.
- **Visual Feedback**: Added a colorful "✨ NEW BEST! ✨" notification in the HUD and updated the game-over screen to display the previous personal best for achievement context.
- **HUD Consistency**: Applied `CLR_SCORE` (Bold Cyan) consistently to both labels and values in the live HUD for better visual balance.

### 🎯 Why
- Clicker games involve rapidly increasing numbers; thousands separators significantly improve glanceability.
- Manual space-padding for carriage-return updates often fails if the new content is shorter than the old, leading to "ghost" characters. ANSI `Erase in Line` is the standard solution.
- Celebrating achievements with historical context (showing the old record) makes the "Win" feel more meaningful.

### ♿ Accessibility
- Improved color contrast and visual hierarchy by using consistent bold styling for primary gameplay metrics.
- Ensured a cleaner terminal state by properly resetting colors and clearing lines, reducing visual noise for users.

---
*PR created automatically by Jules for task [3633522131173303392](https://jules.google.com/task/3633522131173303392) started by @aidasofialily-cmd*