### PR TITLE
🎨 Palette: Explicit Empty States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-05-24 - Explicit Empty States in CLI
+**Learning:** In terminal applications, users benefit from explicit empty states rather than hiding UI elements when there is no data. For example, explicitly showing "None yet! Set a record!" when the highscore is 0 clarifies the achievement system to first-time players.
+**Action:** Always provide encouraging, explicit empty states for data or achievements instead of hiding them, to improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
🎨 Palette: Explicit Empty States

💡 What: Updated the highscore logic to display an explicit empty state ("None yet! Set a record!") when the user has not yet set a high score.
🎯 Why: Previously, the high score display was completely hidden until a score was achieved. This makes the achievement system explicitly known to first-time players, improving onboarding.
📸 Before/After: Visual change in the CLI header upon first startup.
♿ Accessibility: Provides explicit context rather than relying on assumed knowledge of hidden UI elements.

---
*PR created automatically by Jules for task [15072283355042425773](https://jules.google.com/task/15072283355042425773) started by @EiJackGH*