### PR TITLE
🎨 Palette: Add thousands separators and visual polish to HUD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
 
@@ -50,6 +51,17 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO! ✨" << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " ✨ NEW BEST! 🥳" : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "✨ Congratulations! A new personal best! ✨\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
This PR implements several micro-UX improvements to the "Speed Clicker" terminal game:

- **Readability**: Added a `formatWithCommas` helper function to include thousands separators in all score displays (Personal Best, live Score, and Final Score).
- **Visual Polish**: Replaced manual space-padding with the `CLR_EOL` (Erase to Line End) ANSI sequence for cleaner terminal updates during countdowns and HUD refreshes.
- **Achievement Feedback**: Added visual flair (emojis like ✨ and 🥳) to "GO!", "NEW BEST!", and "Congratulations" messages to make milestones feel more celebratory.
- **Consistency**: Standardized HUD coloring by applying `CLR_SCORE` (Bold Cyan) to both the current score and high score values.

These changes make the game interface more intuitive, readable, and pleasant to use without altering any core gameplay logic.

---
*PR created automatically by Jules for task [13110026686868759181](https://jules.google.com/task/13110026686868759181) started by @aidasofialily-cmd*