### PR TITLE
🎨 Palette: Add encouraging empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-05-18 - [Explicit Empty States]
+**Learning:** Users lack context when achievement metrics (like high scores) are hidden by default on first launch.
+**Action:** Provide explicit, encouraging empty states rather than hiding UI elements, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Start clicking!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
What: Added an explicit empty state message when the player has no high score.
Why: Hiding the high score entirely on first launch leaves new users without context. An encouraging empty state clarifies the system state.
Before/After: Before, no high score line was shown on first run. After, it shows 'Personal Best: None yet! Start clicking!'.
Accessibility: Improves cognitive accessibility by clearly defining the expected goal for new users.

---
*PR created automatically by Jules for task [11299833162175004183](https://jules.google.com/task/11299833162175004183) started by @EiJackGH*