### PR TITLE
🎨 Palette: Improve high score empty state and line clearing UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-06-20 - Empty States & ANSI Line Clearing in CLI
+**Learning:** In CLI games, showing nothing when a value (like highscore) is 0 feels broken. Also, hardcoding trailing spaces to overwrite previous output is brittle and can lead to artifacts.
+**Action:** Added an explicit empty state ("0 (Play to set a record!)") for clarity. Replaced hardcoded padding spaces with the exact ANSI 'Erase in Line' sequence `\033[K` immediately after carriage returns (`\r`) to ensure complete and clean line overwrites.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "0 (Play to set a record!)" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -108,7 +110,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r\033[K" << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +143,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r\033[K" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
🎨 Palette: Improve high score empty state and line clearing UX

**What:** 
Added an explicit empty state for the highscore readout in the C++ CLI game and replaced hardcoded output padding spaces with the ANSI 'Erase in Line' escape sequence (`\033[K`). Also added a critical learning journal entry.

**Why:** 
Previously, a score of 0 displayed no text, causing the interface to feel slightly broken to new players. The padding spaces were also brittle when overwriting lines of dynamic length, which could lead to text artifacts remaining on screen. The ANSI 'Erase in Line' sequence is a far more robust, accessible, and standard way of handling console redrawing. 

**Accessibility:** 
Improves interface clarity and robust terminal rendering, preventing visual artifacts that can confuse users or screen readers relying on terminal output states.

**Before/After:**
*(Visual change in CLI output behavior)*

---
*PR created automatically by Jules for task [7561272191942672076](https://jules.google.com/task/7561272191942672076) started by @EiJackGH*