### PR TITLE
🎨 Palette: Add empty state for personal best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-06-21 - Explicit Empty States for Achievements
+**Learning:** In CLI applications, if an achievement (like a high score) is missing, hiding the UI element entirely leaves the user guessing whether the feature exists or is just broken. Explicitly displaying an encouraging empty state clarifies the system state and improves onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state message ("None yet! Go set a record!") to the Personal Best display when the highscore is 0.
🎯 Why: Previously, the UI completely hid the highscore element if it was 0. This left new users guessing whether the feature existed or was just broken. Explicitly displaying an encouraging empty state clarifies the system state and improves onboarding.
📸 Before/After: Before, a new game would show no personal best. After, it explicitly shows "Personal Best: None yet! Go set a record!".
♿ Accessibility: Improves clarity and understanding of the system state for all users. Includes a journal entry for DX/UX learnings.

---
*PR created automatically by Jules for task [5362897093873595675](https://jules.google.com/task/5362897093873595675) started by @EiJackGH*