### PR TITLE
🎨 Palette: Enhance score readability and terminal UI polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-21 - Robust Terminal UI Updates
+**Learning:** Using `\r` (carriage return) for in-place terminal updates is prone to "ghosting" artifacts where characters from longer previous lines remain visible. Furthermore, large numbers are difficult to parse at a glance.
+**Action:** Use `\033[K` (Erase in Line) at the end of carriage-returned output to ensure clean updates, and implement a `formatWithCommas` helper for all numeric displays to improve readability.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_EOL << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | High: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? " ✨ NEW BEST! ✨" : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What: The UX enhancement added
- Introduced a `formatWithCommas` helper to add thousands separators to all numeric score displays (Start Screen, HUD, and Final Score).
- Implemented a `CLR_EOL` macro using the `\033[K` ANSI sequence to ensure clean terminal updates without ghosting artifacts.
- Enhanced the "NEW BEST" notification with sparkles and added the previous best score to the final congratulations message for better context.

### 🎯 Why: The user problem it solves
- Large numbers (e.g., 1000000) are difficult to read at a glance; `1,000,000` is much more intuitive.
- Terminal updates using only `\r` can leave "ghost" characters if the new line is shorter than the old one; `CLR_EOL` guarantees a clean slate.
- Users enjoy immediate and contextual feedback on their achievements.

### ♿ Accessibility: Any a11y improvements made
- Improved visual clarity of scores for all users.
- Consistent use of bold colors for labels and values improves visual hierarchy and focus.

---
*PR created automatically by Jules for task [8207046078791472291](https://jules.google.com/task/8207046078791472291) started by @aidasofialily-cmd*