### PR TITLE
🎨 Palette: Add encouraging empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-06-22 - Explicit Empty States
+**Learning:** Hiding UI elements when data is empty (like a high score of 0) misses an opportunity to encourage user interaction.
+**Action:** Provide explicit, encouraging empty states instead of removing the element entirely.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "0 (Let's set a record!)" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state for the high score ("0 (Let's set a record!)").
🎯 Why: To encourage new players instead of just hiding the high score display when it is 0.
📸 Before/After: Before, no score was shown if high score was 0. After, it shows "0 (Let's set a record!)".
♿ Accessibility: Improves clarity of application state for all users.

---
*PR created automatically by Jules for task [17613903324186565687](https://jules.google.com/task/17613903324186565687) started by @EiJackGH*