### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+## 2024-06-23 - [Explicit Empty States for Onboarding]
+**Learning:** Users benefit more from encouraging empty states for achievements rather than hiding the UI element, clarifying that the feature exists and giving them a goal.
+**Action:** Always provide an explicit, encouraging empty state for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an encouraging "None yet! Set a record!" message when there is no highscore.
🎯 Why: Improves user onboarding by explicitly showing that highscores are tracked, giving new players an immediate goal, rather than just hiding the section entirely.
📸 Before/After: Before, new players saw nothing between the title and controls. After, they see an encouraging prompt to set a record.
♿ Accessibility: Provides clearer system state feedback to all users.

---
*PR created automatically by Jules for task [2567193492164441684](https://jules.google.com/task/2567193492164441684) started by @EiJackGH*