### PR TITLE
🎨 Palette: CLI visual polish and score formatting

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-23 - Standardizing CLI Visual Polish
+**Learning:** For terminal-based games, readability and visual consistency are key UX drivers. Thousands-separator formatting for scores prevents cognitive load as numbers escalate. Furthermore, using the ANSI 'Erase in Line' sequence (`\033[K`) is a more robust pattern than space padding for clearing volatile UI elements, as it guarantees a clean state regardless of previous line length.
+**Action:** Implement `formatWithCommas` for all numeric displays and use a `CLR_EOL` macro for in-place terminal updates to ensure a professional, polished feel.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" << CLR_EOL << "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_EOL << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+            std::cout << "\r" << CLR_EOL << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << " | High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_CTRL " ✨ NEW BEST! ✨" CLR_RESET : "")
+                      << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_CTRL << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")" << CLR_RESET << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 💡 What: The UX enhancement added
- Added a `formatWithCommas` helper to provide thousands separators for all numeric displays (Start Screen, HUD, Game Over Screen).
- Introduced a `CLR_EOL` macro utilizing the ANSI `\033[K` (Erase in Line) sequence for cleaner, flicker-free terminal updates.
- Refined the in-game HUD with standardized `CLR_SCORE` (Bold Cyan) styling for both labels and values.
- Enhanced the achievement celebration with color and stylized text: `✨ NEW BEST! ✨`.
- Improved the congratulations message to include the previous record for better context.

### 🎯 Why: The user problem it solves
- **Readability:** Large numeric scores (e.g., 1000000) are difficult to parse quickly in a high-speed game; 1,000,000 is much clearer.
- **Visual Integrity:** Manual space-padding often leaves "ghost" characters if the new line is shorter than the previous one; `CLR_EOL` guarantees a clean state.
- **Engagement:** Providing context for achievements (comparing the new score to the previous best) makes the win feel more meaningful.

### ♿ Accessibility & Polish
- Improved color contrast and consistency across the CLI interface.
- Reduced visual noise by using robust terminal control sequences instead of repetitive character output.
- Enhanced the tactical feel of the game with immediate, clear visual milestones.

---
*PR created automatically by Jules for task [1737781633182001976](https://jules.google.com/task/1737781633182001976) started by @aidasofialily-cmd*