### PR TITLE
🎨 Palette: Improve Highscore Empty State and Terminal Artifacts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-15 - Explicit Empty States for Onboarding
+**Learning:** In interactive CLI applications, leaving achievement fields (like high scores) hidden until a record is set can confuse new users about the game's goals. Providing an explicit, encouraging empty state (e.g., "None yet! Set a record!") clarifies the objective and improves initial engagement.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -78,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +97,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +111,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +144,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:** 
- Added an explicit "None yet! Set a record!" empty state for the personal best score when `highscore == 0`.
- Replaced hardcoded spaces used for clearing terminal line trailing artifacts with the `\033[K` (Erase in Line) ANSI escape sequence.

🎯 **Why:**
- Leaving the achievement hidden until it was achieved created confusion for new users about the game's ultimate goal. The explicit empty state encourages engagement right away.
- Padding strings with spaces is a fragile way to update lines via carriage return. Using the correct ANSI escape sequence prevents leftover "ghost" characters when string lengths change, leading to a much smoother CLI experience.

📸 **Before/After:**
- **Before:** If high score was 0, nothing was shown. Terminal lines had ugly padded spaces at the end: `std::cout << "\r" << "GO!             " << ...`
- **After:** Displays `Personal Best: None yet! Set a record!`. Updates are handled cleanly: `std::cout << "\r" ERASE_LINE << "GO!" << ...`

♿ **Accessibility:**
- Clarifies the system state for users instantly.
- Removes distracting visual "ghost" artifacts during high-speed CLI interactions.

---
*PR created automatically by Jules for task [2723553132938103295](https://jules.google.com/task/2723553132938103295) started by @EiJackGH*