### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-05-24 - Encouraging Empty States in CLI
+**Learning:** When displaying achievements or data in a CLI, hiding the section when empty (like a high score of 0) misses an opportunity to onboard and encourage the user. Providing an explicit, friendly empty state clarifies the system's capabilities and motivates interaction.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Added an explicit, encouraging empty state for the "Personal Best" section in the CLI game.
🎯 **Why**: Previously, if the high score was 0 (e.g., for a first-time player), the entire "Personal Best" section was hidden. Hiding empty states misses an opportunity to onboard the user. An explicit empty state clarifies that scores *are* tracked and encourages the user to play and set a record.
📸 **Before/After**:
*   *Before*: Nothing displayed between the title block and the "Controls" section for new players.
*   *After*: Displays `Personal Best: None yet! Set a record!` in standard text color.
♿ **Accessibility**: Improves cognitive accessibility by providing immediate, explicit feedback about the system's capabilities (score tracking) rather than requiring the user to discover it through action.

---
*PR created automatically by Jules for task [13506170182277962457](https://jules.google.com/task/13506170182277962457) started by @EiJackGH*