### PR TITLE
🎨 Palette: Improve HUD readability and number formatting

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2026-06-25 - Robust Terminal Line Clearing
+**Learning:** Using space padding to clear previous terminal output is brittle and depends on knowing the previous string's length. Utilizing the ANSI 'Erase in Line' escape sequence (\033[K) via a CLR_EOL macro provides a robust way to ensure no "ghost" characters remain from previous outputs, especially when switching between strings of varying lengths.
+**Action:** Use CLR_EOL at the end of carriage-returned (\r) lines in CLI applications to guarantee clean visual transitions without manual space management.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,21 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = static_cast<int>(s.length());
+    int limit = (value < 0) ? 1 : 0;
+    int insertPosition = n - 3;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +90,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +107,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +121,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +154,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << CLR_RESET << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
+                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]") << CLR_RESET
+                      << (score > initialHighscore ? CLR_CTRL " NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,7 +168,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
### 💡 What
This enhancement adds human-readable number formatting (commas) to all score displays and replaces brittle space-padding with the ANSI "Erase in Line" sequence (`\033[K`) for cleaner terminal updates.

### 🎯 Why
In a high-speed clicker game, large numbers become difficult to parse quickly without thousands separators. Additionally, the previous method of space-padding could leave "ghost" characters if a new line was significantly shorter than the previous one.

### ♿ Accessibility & UX
- **Readability:** Numbers are now formatted (e.g., `1,234,567` instead of `1234567`).
- **Visual Polish:** `CLR_EOL` ensures a crisp transition during the countdown and live score updates.
- **Hierarchy:** Consistent use of `CLR_SCORE` (Bold Cyan) for both labels and values in the HUD improves visual balance.
- **Color Hygiene:** Explicit `CLR_RESET` is applied after mode indicators to prevent color bleed into the HUD or the user's shell.

---
*PR created automatically by Jules for task [1691754119858844486](https://jules.google.com/task/1691754119858844486) started by @aidasofialily-cmd*