### PR TITLE
🎨 Palette: Add explicit empty states and robust line clearing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2024-06-26 - Empty States and Terminal Line Erasing
+**Learning:** In CLI applications, explicitly handling empty states (like a first-time player with a 0 high score) improves onboarding UX, replacing an implicit absence of data with encouraging text. Additionally, when dynamically updating terminal lines using `\r`, relying on hardcoded padding spaces to clear previous text leads to visual artifacts if the new string is shorter.
+**Action:** Use the ANSI `\033[K` (Erase in Line) sequence immediately after `\r` to cleanly overwrite terminal lines, and always provide explicit, positive empty states instead of hiding UI elements.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define ERASE_LINE "\033[K"
 
 struct termios oldt;
 
@@ -78,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +97,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\r" ERASE_LINE "Starting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +111,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" ERASE_LINE << CLR_NORM << "GO!" << CLR_RESET << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +144,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << std::flush;
             updateUI = false;
         }
     }


### PR DESCRIPTION
💡 **What:**
- Added an explicit empty state for the "Personal Best" section when the high score is 0 ("None yet! Set a record!").
- Replaced hardcoded padding spaces used to clear terminal lines with the standard ANSI `\033[K` (Erase in Line) sequence (`ERASE_LINE`).

🎯 **Why:**
- **Empty State:** Replaces an implicit absence of data with an encouraging message, improving the onboarding experience for first-time players.
- **Line Clearing:** Relying on hardcoded spaces to clear previous text is fragile and can lead to visual artifacts if the new string is shorter than the old one. The ANSI sequence cleanly and robustly erases the rest of the line.

📸 **Before/After:**
- *Before:* First-time players see no high score section at all. Terminal updates rely on `std::cout << "\r" << "Score: " << score << "           " << std::flush;`
- *After:* First-time players see "Personal Best: None yet! Set a record!". Terminal updates use `std::cout << "\r" ERASE_LINE << "Score: " << score << std::flush;`

♿ **Accessibility/UX:**
- Provides clearer system state feedback to new users.
- Ensures a cleaner, artifact-free visual experience during dynamic terminal updates.

---
*PR created automatically by Jules for task [8086943813648974853](https://jules.google.com/task/8086943813648974853) started by @EiJackGH*