### PR TITLE
🎨 Palette: Improve terminal UX with score formatting and robust line clearing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-01-24 - Real-time Achievement Feedback in CLI
 **Learning:** In terminal-based games, displaying achievement progress (like a live high score) in real-time provides immediate tactile reward and engagement. Furthermore, inclusive UX means ensuring first-time players also receive "New Best" feedback, even when their initial record is zero.
 **Action:** Update session-high-score variables immediately upon record-breaking and display them in the live HUD. Ensure achievement conditions (`score > highscore`) don't exclude the first-time user experience.
+
+## 2025-01-24 - Robust In-place Terminal Updates
+**Learning:** In CLI applications, using space padding to clear previous characters during in-place updates (carriage returns) is fragile and prone to leaving "ghost" characters if the new content is shorter or if formatting (like thousands separators) changes the string length. The ANSI "Erase in Line" escape sequence (\033[K) is a more robust solution that guarantees the removal of all characters from the cursor to the end of the line.
+**Action:** Use a `CLR_EOL` (\033[K) macro for all in-place terminal UI updates to ensure a clean visual state regardless of content length variations.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,20 @@
 #define CLR_NORM  "\033[1;32m"
 #define CLR_CTRL  "\033[1;33m"
 #define CLR_RESET "\033[0m"
+#define CLR_EOL   "\033[K"
 
 struct termios oldt;
+
+std::string formatWithCommas(long long n) {
+    std::string s = std::to_string(n);
+    int limit = (n < 0) ? 1 : 0;
+    int pos = static_cast<int>(s.length()) - 3;
+    while (pos > limit) {
+        s.insert(pos, ",");
+        pos -= 3;
+    }
+    return s;
+}
 
 void restore_terminal(int signum) {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
@@ -77,7 +89,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -94,7 +106,7 @@ int main() {
     }
 
     for (int i = 3; i > 0; --i) {
-        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << std::flush;
+        std::cout << "\rStarting in " << CLR_CTRL << i << CLR_RESET << "... " << CLR_EOL << std::flush;
         auto start_wait = std::chrono::steady_clock::now();
         while (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count() < 1000) {
             int elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_wait).count();
@@ -108,7 +120,7 @@ int main() {
             }
         }
     }
-    std::cout << "\r" << CLR_NORM << "GO!             " << CLR_RESET << "\n" << std::flush;
+    std::cout << "\r" << CLR_NORM << "GO!" << CLR_RESET << CLR_EOL << "\n" << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
@@ -141,10 +153,11 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" << CLR_SCORE << "Score: " << formatWithCommas(score)
+                      << " | High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
-                      << "           " << std::flush;
+                      << (score > initialHighscore ? CLR_CTRL " ✨ NEW BEST! 🥳" CLR_RESET : "")
+                      << CLR_EOL << std::flush;
             updateUI = false;
         }
     }
@@ -154,9 +167,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_CTRL << "Congratulations! A new personal best! (Previous: " << formatWithCommas(initialHighscore) << ")" << CLR_RESET << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 🎨 Palette: Improve terminal UX with score formatting and robust line clearing

#### 💡 What:
This PR introduces several micro-UX improvements to the Speed Clicker terminal game:
- **Score Readability:** Added a `formatWithCommas` utility to display scores with thousands separators (e.g., `1,250` instead of `1250`).
- **Robust Line Clearing:** Replaced manual space-padding with the ANSI "Erase in Line" escape sequence (`\033[K`) via a new `CLR_EOL` macro, ensuring clean UI updates during gameplay and countdowns.
- **Visual Polish:** Standardized HUD coloring (Bold Cyan) and added emojis/visual flair (`✨`) to record-breaking celebrations.
- **Achievement Context:** The final congratulations message now includes the previous high score to highlight the magnitude of the improvement.

#### 🎯 Why:
Large numbers are difficult to parse at a glance in a fast-paced game. Additionally, relying on space-padding for terminal updates is fragile and often leaves "ghost" characters if the new line content is shorter than the previous one. These changes improve both the aesthetic and the functional reliability of the CLI interface.

#### ♿ Accessibility:
- Improved readability of large numbers through formatting.
- Enhanced visual hierarchy and feedback for key game states (Start, Goal, Achievements).

#### ✅ Verification:
- Compiled successfully with `make`.
- Verified UX standards (cursor handling) with `python3 verify_ux.py`.
- Logic for `formatWithCommas` handles large values and zero correctly.
- Manual verification of terminal output ensures no color bleed and clean line transitions.

---
*PR created automatically by Jules for task [3740313757414623336](https://jules.google.com/task/3740313757414623336) started by @aidasofialily-cmd*