### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-24 - Empty States as Onboarding
+**Learning:** In CLI applications, omitting an element when data is empty (like a high score of 0) creates a confusing first-time user experience. Users might not know the feature exists. Providing an explicit, encouraging empty state (e.g., "None yet! Set a record!") acts as onboarding, clarifying the system state and motivating interaction.
+**Action:** Always provide explicit empty states for data or achievements rather than hiding the UI element, to improve onboarding and clarity.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Added an explicit empty state string ("None yet! Set a record!") for when the high score is 0.
🎯 **Why**: To help onboard new users and make the app more engaging instead of just hiding the high score section.
📸 **Before/After**: Before, a new user saw nothing about "Personal Best". After, they see an encouraging message to set a record.
♿ **Accessibility**: Provides clear system status and avoids an invisible state.

---
*PR created automatically by Jules for task [1561286557942140208](https://jules.google.com/task/1561286557942140208) started by @EiJackGH*