### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-06-28 - Explicit Empty States in CLI
+**Learning:** When implementing UX in CLI applications, hiding a UI element when data is empty (like a high score) leaves the user guessing about the system state. Providing explicit, encouraging empty states clarifies the system state and improves user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element, to clarify system state and improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state ("None yet! Set a record!") for the high score display when the highscore is 0, rather than simply hiding the UI element.
🎯 Why: Hiding elements when data is empty leaves users guessing about the system state or feature existence. An explicit, encouraging empty state clarifies the system state and improves onboarding.
📸 Before/After: Before, if `highscore <= 0`, no personal best information was shown. After, it explicitly states there is no record yet and encourages the user to set one.
♿ Accessibility: Improves cognitive accessibility and system status visibility by removing ambiguity about whether high scores are tracked.

---
*PR created automatically by Jules for task [2909086195805845047](https://jules.google.com/task/2909086195805845047) started by @EiJackGH*