### PR TITLE
🎨 Palette: Improve score readability and achievement feedback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,16 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int start = (value < 0) ? 1 : 0;
+    for (int i = n - 3; i > start; i -= 3) {
+        s.insert(i, ",");
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -78,7 +88,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -142,9 +152,10 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET
+                      << " | " << CLR_SCORE << "High: " << formatWithCommas(highscore) << CLR_RESET << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+                      << (score > initialHighscore ? CLR_CTRL " ✨ NEW BEST! 🥳" CLR_RESET : "")
                       << std::flush;
             updateUI = false;
         }
@@ -155,9 +166,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "Congratulations! A new personal best (previous: " << formatWithCommas(initialHighscore) << ")!\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
I have implemented a few micro-UX improvements to the "Speed Clicker" game:
1. **Thousands-Separators:** Large scores are now formatted with commas (e.g., `1,000,000` instead of `1000000`) using a new `formatWithCommas` helper.
2. **Visual Flair:** The "NEW BEST!" message now includes sparkles (`✨`) and is styled with `CLR_CTRL` (Bold Yellow) for better celebratory impact.
3. **HUD Consistency:** Both the "Score:" and "High:" labels in the HUD are now styled with `CLR_SCORE` (Bold Cyan) for a more balanced look.
4. **Contextual Feedback:** The final congratulations message now explicitly mentions the previous personal best, helping players appreciate the scale of their improvement.
5. **Terminal Hygiene:** Added missing `CLR_RESET` sequences to ensure no color bleeds into the user's shell after gameplay.

---
*PR created automatically by Jules for task [821922923110433119](https://jules.google.com/task/821922923110433119) started by @aidasofialily-cmd*