### PR TITLE
🎨 Palette: Add encouraging empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-06-29 - Encouraging Empty States
+**Learning:** Hiding UI elements like "Personal Best" when there's no data (e.g., highscore is 0) leaves new users without context or a goal. Providing an explicit, encouraging empty state (like "None yet! Set a record!") clarifies the system state and improves user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Replaced the empty state behavior for the high score display. Instead of hiding the "Personal Best" section when the high score is 0, it now displays an encouraging message: "None yet! Set a record!".
🎯 **Why:** Hiding UI elements like "Personal Best" when there's no data leaves new users without context or a goal. Providing an explicit, encouraging empty state clarifies the system state, improves user onboarding, and gives them an immediate objective.
📸 **Before/After:**
*   **Before:** (On first run, highscore 0) The "Personal Best" line was entirely missing.
*   **After:** (On first run, highscore 0) Displays: `Personal Best: None yet! Set a record!`
♿ **Accessibility:** Improves cognitive accessibility by explicitly stating the game's goal and current state, rather than relying on the user to infer it from missing information.

---
*PR created automatically by Jules for task [13425118157128037546](https://jules.google.com/task/13425118157128037546) started by @EiJackGH*