### PR TITLE
🎨 Palette: Explicit high score empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-05-15 - Empty State for Achievements
+**Learning:** Providing explicit, encouraging empty states for data or achievements clarifies system state and improves user onboarding, rather than hiding the UI element when empty.
+**Action:** Added an explicit empty state to the high score display in the C++ CLI app.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state to the high score display.
🎯 **Why:** To clarify system state and improve user onboarding by providing an encouraging empty state instead of hiding the UI element completely when the user has no high score.
📸 **Before/After:**
*   **Before:** If the high score is 0, the "Personal Best" line is completely absent from the startup screen.
*   **After:** If the high score is 0, the startup screen explicitly displays: `Personal Best: None yet! Set a record!`
♿ **Accessibility:** Improves cognitive accessibility and onboarding by making the system state (having no score) explicit rather than implied by absence.

---
*PR created automatically by Jules for task [15379137054611420907](https://jules.google.com/task/15379137054611420907) started by @EiJackGH*