### PR TITLE
🎨 Palette: Add encouraging empty state for new players

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-05-25 - Encouraging Empty States in CLI
+**Learning:** In CLI games, missing UI elements like a high score when the user hasn't played yet can leave them confused or feeling unsupported. Providing an explicit, encouraging empty state for data (like a "None yet! Start clicking!" message instead of hiding the high score completely) clarifies the system state and improves the onboarding experience for new users.
+**Action:** Provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Start clicking to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit, encouraging string in the CLI displaying "None yet! Start clicking to set a record!" for users who have not yet established a high score, instead of simply omitting the `Personal Best:` line entirely.

🎯 Why: In CLI games (and UI generally), missing UI elements can leave users confused about system state. Providing an explicit empty state instead of hiding the component improves user onboarding by giving them a clear path forward.

📸 Before/After: Visual change in the CLI upon the very first launch. 
Before: 
```
==========================
      SPEED CLICKER
==========================
Controls:
```
After:
```
==========================
      SPEED CLICKER
==========================
 Personal Best: None yet! Start clicking to set a record!

Controls:
```

♿ Accessibility: Ensures that players starting their session from scratch aren't met with potentially confusing missing interface elements but have contextual clarity.

---
*PR created automatically by Jules for task [17778748581225222900](https://jules.google.com/task/17778748581225222900) started by @EiJackGH*