### PR TITLE
🎨 Palette: Add explicit empty state for personal best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-02 - Explicit Empty States for Achievements
+**Learning:** In CLI applications, hiding achievement sections (like personal bests) when empty can leave new users confused about the system state. Providing an explicit, encouraging empty state clarifies that achievements exist and incentivizes onboarding.
+**Action:** Always provide encouraging empty state messages (e.g., "None yet! Play to set one!") instead of completely hiding the UI elements when data is empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state ("None yet! Play to set one!") for the Personal Best score when it is zero.

🎯 **Why:** Previously, if a user had no high score, the UI completely hid the "Personal Best" line. This left new users without a clear understanding of the achievement system. Providing an explicit, encouraging empty state clarifies that achievements exist and incentivizes onboarding gameplay.

📸 **Before/After:**
*Before:* `Personal Best` line was completely missing on first launch.
*After:* `Personal Best: None yet! Play to set one!` is displayed in the standard UI colors.

♿ **Accessibility:** Improves cognitive accessibility and onboarding clarity by explicitly communicating system state rather than hiding elements.

---
*PR created automatically by Jules for task [12171574394039105282](https://jules.google.com/task/12171574394039105282) started by @EiJackGH*