### PR TITLE
🎨 Palette: Add empty state for personal best score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-23 - Empty States for Achievements
+**Learning:** Hiding UI elements like a high score when empty can leave users confused about the system state and what they are working towards. Providing an explicit, encouraging empty state clarifies the goal and improves onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state for the personal best score when it is 0.
🎯 Why: Previously, the highscore UI was simply hidden if the user had not yet scored. Hiding UI elements like achievements can leave users confused about the system state and what they are working towards. Providing an explicit, encouraging empty state ("None yet! Set a record!") clarifies the goal and improves the onboarding experience.
📸 Before/After: Before, a new player saw no mention of a highscore. Now, they see "Personal Best: None yet! Set a record!".
♿ Accessibility: Improves cognitive accessibility by explicitly stating the system's state rather than relying on the user to notice the absence of a UI element.

---
*PR created automatically by Jules for task [8423091558609906492](https://jules.google.com/task/8423091558609906492) started by @EiJackGH*