### PR TITLE
🎨 Palette: Comma format for scores

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,18 @@ void save_highscore(long long score) {
     }
 }
 
+std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = s.length();
+    int start = (value < 0) ? 1 : 0;
+    int insertPosition = n - 3;
+    while (insertPosition > start) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
 int main() {
     struct termios newt;
     if (tcgetattr(STDIN_FILENO, &oldt) == -1) {
@@ -78,7 +90,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -142,7 +154,7 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳" : "")
                       << std::flush;
@@ -155,7 +167,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added comma formatting to numeric scores (e.g., "1,234,567" instead of "1234567").

### 🎯 Why: The user problem it solves
Large numbers are difficult to read at a glance in a fast-paced "Speed Clicker" game. Adding commas significantly improves readability and makes the achievement feel more "official" and satisfying.

### ♿ Accessibility: Any a11y improvements made
Improved visual clarity for all users, particularly helpful for those with cognitive disabilities who might struggle with parsing long strings of digits.

Verified with a standalone test suite and ensured core UX standards (like cursor management) are preserved.

---
*PR created automatically by Jules for task [10212149749757914543](https://jules.google.com/task/10212149749757914543) started by @aidasofialily-cmd*