### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-25 - Explicit Empty States for Achievements
+**Learning:** Hiding achievement UI elements (like a high score) when the user has no data can leave new users confused about the game's goals. Providing an explicit, encouraging empty state (e.g., "None yet. Set a record!") clarifies the system state, introduces the goal, and improves user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet. Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Replaced a hidden UI state for new players with an explicit, encouraging empty state message ("None yet. Set a record!").
🎯 Why: Hiding achievement UI elements when the user has no data can leave new users confused about the game's goals. An explicit empty state clarifies the system state, introduces the goal, and improves user onboarding.
📸 Before/After: Before, a first-time player saw no mention of a high score. Now, they see "Personal Best: None yet. Set a record!"
♿ Accessibility: Improves cognitive accessibility by clearly defining the goal and system state for new users, rather than relying on them to discover it organically.

---
*PR created automatically by Jules for task [2871330578545173002](https://jules.google.com/task/2871330578545173002) started by @EiJackGH*