### PR TITLE
🎨 Palette: Implement comma formatting for scores

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-07-04 - Comma Formatting for CLI Readability
+**Learning:** In clicker-style CLI games, numeric scores can grow rapidly. Comma formatting (e.g., '1,234,567') significantly improves readability and the "feel" of progress compared to raw integers, making large achievements more immediately apparent to the player.
+**Action:** Move shared logic (like number formatters) to a header file to avoid duplication and enable consistent formatting across both main application and test suites.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include "utils.hpp"
 
 // Color and formatting macros for terminal output
 #define RESET     "\033[0m"
@@ -78,7 +79,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -142,9 +143,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+                      << (score > initialHighscore ? " NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" : "")
                       << std::flush;
             updateUI = false;
         }
@@ -155,7 +156,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,21 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
+#include <string>
+
+/**
+ * Formats a long long value with commas as thousands separators.
+ * Example: 1000 -> "1,000", 1000000 -> "1,000,000"
+ */
+inline std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    int limit = (value < 0) ? 1 : 0;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
+#endif


### PR DESCRIPTION
💡 What: This PR introduces thousand-separator formatting (commas) for scores in the Speed Clicker game. It also enhances the achievement feedback by displaying the previous personal best when a new record is set.

🎯 Why: As scores in clicker games grow rapidly, raw integers become difficult to read at a glance. Comma formatting (e.g., "1,000,000") provides immediate clarity. Including the previous high score in the "NEW BEST!" message adds meaningful context to the achievement.

♿ Accessibility: Improved readability for all users, particularly those who process grouped numbers more easily.

📸 Changes:
- `Score: 1000` -> `Score: 1,000`
- `NEW BEST! 🥳` -> `NEW BEST! 🥳 (was 900)`

---
*PR created automatically by Jules for task [17125428020385777333](https://jules.google.com/task/17125428020385777333) started by @aidasofialily-cmd*