### PR TITLE
🎨 Palette: Add encouraging empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-06-01 - Welcoming Empty States in CLI
+**Learning:** In CLI applications, explicitly displaying encouraging empty states (e.g., "None yet! Set a record!") for data or achievements clarifies the system state and improves user onboarding, rather than silently hiding the UI element when empty.
+**Action:** Always provide explicit, encouraging empty states for data or achievements to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state to the high score display.
🎯 **Why:** To improve onboarding for new players by explicitly showing the high score section with an encouraging message, rather than silently hiding it when the score is zero.
📸 **Before/After:** Before: Section hidden if highscore = 0. After: Displays "Personal Best: None yet! Set a record!".
♿ **Accessibility:** Clarifies system state for all users, providing immediate context on what to achieve.

---
*PR created automatically by Jules for task [11939376351567401050](https://jules.google.com/task/11939376351567401050) started by @EiJackGH*