### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-28 - Explicit Empty States in CLI
+**Learning:** In terminal applications, hiding UI elements (like a high score) when data is absent can leave the user unsure of the system state or unaware that a feature exists.
+**Action:** Provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet - go set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state message ("None yet - go set one!") for the Personal Best display when the score is 0.
🎯 **Why:** Previously, if a user had no high score, the entire Personal Best display was completely hidden. In terminal applications, hiding UI elements when data is absent can leave the user unsure of the system state or unaware that a feature exists. Providing an explicit, encouraging empty state clarifies the system state and improves user onboarding.
📸 **Before/After:**
Before: [No output for Personal Best if score is 0]
After: `Personal Best: None yet - go set one!`
♿ **Accessibility/UX:** Improves the initial user experience by providing clear feedback on the current state of the application's achievement system.

---
*PR created automatically by Jules for task [7317332222582443411](https://jules.google.com/task/7317332222582443411) started by @EiJackGH*