### PR TITLE
🎨 Palette: Add explicit empty state for personal best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-28 - Explicit Empty States in CLI
+**Learning:** Hiding UI elements like high scores when they are empty (e.g., zero) creates an ambiguous state for new users, leaving them unaware that such a feature exists. Providing an explicit, encouraging empty state (like "None yet. Set a record!") clarifies the system state, introduces the feature, and improves user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements in CLI applications rather than simply hiding the UI element when empty.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet. Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**What:**
Modified the `src/main.cpp` file to include an explicit `else` block when checking if `highscore > 0`. If the highscore is 0, the game now displays: `Personal Best: None yet. Set a record!`. Also appended a corresponding UX learning to `.Jules/palette.md`.

**Why:**
Hiding UI elements (like a high score) when they are empty creates an ambiguous state for new users, leaving them unaware that such a feature exists. An explicit, encouraging empty state clarifies the system state, introduces the feature, and improves user onboarding.

**Before/After:**
- **Before:** If highscore is 0, no Personal Best section is displayed.
- **After:** If highscore is 0, the game displays `Personal Best: None yet. Set a record!`.

**Accessibility:**
Clarifies system capabilities and expectations for new users instead of relying on discovery through repeated play, which aligns with cognitive accessibility principles regarding clear instructions and predictable states.

---
*PR created automatically by Jules for task [6443492757932510627](https://jules.google.com/task/6443492757932510627) started by @EiJackGH*