### PR TITLE
🎨 Palette: Comma-formatted scores and enhanced achievement feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-07-08 - Contextual Achievement Feedback in CLI
+**Learning:** In terminal games, simply announcing a "NEW BEST" provides feedback but lacks context. Including the previous record (e.g., "was 1,234") alongside the new score provides an immediate sense of growth and achievement magnitude. Combined with thousand-separator formatting, this makes numeric milestones much more readable and rewarding.
+**Action:** Always provide context (previous values) when announcing records or significant state changes, and use standard numeric formatting (commas) for all high-value integers to improve at-a-glance readability.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include "utils.hpp"
 
 // Color and formatting macros for terminal output
 #define RESET     "\033[0m"
@@ -78,7 +79,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -142,9 +143,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+                      << (score > initialHighscore ? CLR_CTRL " NEW BEST! ✨🥳 (was " + formatWithCommas(initialHighscore) + ")" CLR_RESET : "")
                       << std::flush;
             updateUI = false;
         }
@@ -155,9 +156,9 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_CTRL << "Congratulations! A new personal best! ✨" << CLR_RESET << "\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,18 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
+#include <string>
+
+inline std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int n = static_cast<int>(s.length());
+    int limit = (value < 0) ? 1 : 0;
+    int insertPosition = n - 3;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
+#endif


### PR DESCRIPTION
💡 **What:** This PR introduces comma-formatting for all numeric scores and enhances the "New Personal Best" achievement feedback.
- A new header `src/utils.hpp` provides a `formatWithCommas` function.
- Scores in the HUD, initial personal best, and final score summary now use thousands-separators (e.g., `1,234` instead of `1234`).
- The "NEW BEST!" message now includes the previous high score for context (e.g., `NEW BEST! ✨🥳 (was 1,000)`) and is highlighted in Bold Yellow.

🎯 **Why:** In a fast-paced "Speed Clicker" game, raw integers become difficult to parse quickly as they grow. Adding commas improves at-a-glance readability. Providing the previous high score context makes reaching a new milestone feel more tangible and rewarding.

♿ **Accessibility:** Improved readability of numeric information in the terminal UI.

---
*PR created automatically by Jules for task [14317595766223097071](https://jules.google.com/task/14317595766223097071) started by @aidasofialily-cmd*