### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-07-09 - Add explicit empty state for highscore
+**Learning:** Providing explicit, encouraging empty states for data or achievements clarifies system state and improves user onboarding in CLI applications, rather than hiding the UI element completely when empty.
+**Action:** Always provide an explicit empty state for optional or user-generated data to confirm functionality and encourage interaction.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state when the user has no highscore.
🎯 Why: To clarify the system state and improve user onboarding instead of hiding the personal best line completely.
📸 Before/After: Before, no personal best was displayed if the highscore was 0. After, it shows "Personal Best: None yet! Go set one!".
♿ Accessibility: Improves cognitive accessibility by providing an explicit and encouraging system status.

---
*PR created automatically by Jules for task [8851846643600692844](https://jules.google.com/task/8851846643600692844) started by @EiJackGH*