### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-10 - Explicit Empty States for Achievements
+**Learning:** In CLI applications, omitting an achievement (like a high score) when the value is 0 or uninitialized leaves the user unaware that the feature exists or what the baseline state is.
+**Action:** Provide explicit, encouraging empty states (e.g., "None yet! Play to set one!") rather than hiding the UI element, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**What:** Added an explicit empty state message ("None yet! Play to set one!") for the high score when it is 0, instead of hiding the high score display entirely.
**Why:** To clarify the system state for new players, letting them know that a high score feature exists and encouraging them to play.
**Before/After:** Before, the high score line was completely hidden if the score was 0. After, it explicitly shows that there is no high score yet.
**Accessibility:** Improves cognitive accessibility and onboarding by making the game's achievement system transparent from the start.

---
*PR created automatically by Jules for task [9244773722105002266](https://jules.google.com/task/9244773722105002266) started by @EiJackGH*