### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-24 - Add Empty State for Highscore
+**Learning:** Providing explicit, encouraging empty states (e.g., "None yet! Set one!") in CLI applications clarifies system state and improves user onboarding compared to simply hiding the UI element when data is empty.
+**Action:** Always provide helpful empty states for data or achievements instead of hiding them.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state ("None yet! Set one!") for the highscore.
🎯 Why: To clarify system state and improve user onboarding by explicitly acknowledging the lack of a highscore, rather than just hiding the text.
📸 Before/After: Visual change in terminal output on first run.
♿ Accessibility: Improves clarity and understanding of the game's state.

---
*PR created automatically by Jules for task [10868652746282208282](https://jules.google.com/task/10868652746282208282) started by @EiJackGH*