### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-07-13 - Empty States in CLI
+**Learning:** Hiding UI elements (like high scores) when data is absent leaves users guessing if the feature exists. Providing an explicit, encouraging empty state clarifies system capabilities and improves onboarding.
+**Action:** Always provide explicit empty states for data or achievements rather than hiding the UI element when empty.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet - go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Added an explicit empty state string to the highscore display in `src/main.cpp`.
🎯 **Why**: Hiding UI elements when data is absent leaves users guessing if a feature exists. An encouraging empty state clarifies the system capabilities and improves the onboarding experience.
📸 **Before/After**: Before, a new player with a 0 score saw nothing. After, they see "Personal Best: None yet - go set a record!".
♿ **Accessibility**: Provides clearer context to users about their progress state.

---
*PR created automatically by Jules for task [6452555263419011065](https://jules.google.com/task/6452555263419011065) started by @EiJackGH*