### PR TITLE
🎨 Palette: Add empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-14 - Empty States in CLI Applications
+**Learning:** When implementing UX in CLI applications, provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.
+**Action:** Always show an empty state (e.g., "None yet! Go set a record!") for zero-values rather than just hiding the section, to let the user know what the system state is.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Changed the highscore display to explicitly state "None yet! Go set a record!" when the highscore is 0, rather than silently hiding the element.
🎯 Why: To improve user onboarding by clarifying the system state and encouraging engagement for first-time players.
📸 Before/After: N/A (CLI change)
♿ Accessibility: Provides explicit context rather than relying on absence of information.

---
*PR created automatically by Jules for task [17735109122266139233](https://jules.google.com/task/17735109122266139233) started by @EiJackGH*