### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-05-24 - Encouraging Empty States in CLI
+**Learning:** When displaying achievements or data points that are initially zero or empty, leaving the UI blank or just showing '0' can feel unwelcoming. Providing an explicit, encouraging empty state (like "Let's set a record!") clarifies the system state and improves user onboarding by giving them a clear goal.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "0 (Let's set a record!)" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an encouraging explicit empty state message ("Let's set a record!") for the initial highscore display instead of relying on a blank UI state when the highscore is 0.
🎯 Why: When displaying achievements or data points that are initially empty, leaving the UI blank can feel unwelcoming. Providing an explicit, encouraging empty state clarifies the system state and improves user onboarding by giving them a clear goal.
📸 Before/After: Before, no highscore line was shown on the first run. Now, `Personal Best: 0 (Let's set a record!)` is displayed.
♿ Accessibility: Improves cognitive accessibility by clearly defining the starting state and expectations for the user.

---
*PR created automatically by Jules for task [6432341050101653895](https://jules.google.com/task/6432341050101653895) started by @EiJackGH*