### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-16 - Add explicit empty state for high score
+**Learning:** Providing an explicit empty state instead of hiding elements clarifies the system state and improves user onboarding.
+**Action:** Provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
### 💡 What
Added an explicit, encouraging empty state for the "Personal Best" score display when a user plays the game for the first time (i.e., when `highscore == 0`). 

### 🎯 Why
Previously, if a user had no high score, the "Personal Best" line was completely omitted from the UI. Hiding UI elements dynamically can leave users wondering where that data lives or if the feature is broken. An explicit empty state ("None yet! Play to set one!") clarifies the system state, acts as a gentle call-to-action, and improves the onboarding experience for new players.

### 📸 Before/After
**Before (New Player):**
```
==========================
      SPEED CLICKER
==========================
Controls:
 [h] Toggle Hard Mode (10x Speed!)
...
```

**After (New Player):**
```
==========================
      SPEED CLICKER
==========================
 Personal Best: None yet! Play to set one!

Controls:
 [h] Toggle Hard Mode (10x Speed!)
...
```

### ♿ Accessibility
While primarily a usability and onboarding improvement, providing explicit textual states rather than relying on visual absence makes the application logic clearer and easier to parse for all users.

---
*PR created automatically by Jules for task [1008036951818451356](https://jules.google.com/task/1008036951818451356) started by @EiJackGH*