### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-24 - Explicit Empty States for Achievements
+**Learning:** Hiding achievement metrics (like high scores) when they are zero or empty removes a motivating goal for new users and obscures system capabilities.
+**Action:** Provide an explicit, encouraging empty state (e.g., "None yet! Play to set a record!") to clarify system capabilities and improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
Added an explicit empty state for the highscore to motivate new users and clarify system capabilities. Recorded the UX learning in the Palette journal.

---
*PR created automatically by Jules for task [8041232082915244313](https://jules.google.com/task/8041232082915244313) started by @EiJackGH*