### PR TITLE
🎨 Palette: Add explicit empty state for personal best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-18 - Encouraging Empty States
+**Learning:** Providing explicit, encouraging empty states for data or achievements, rather than hiding the UI element when empty, clarifies the system state and improves user onboarding.
+**Action:** Always include a welcoming empty state rather than omitting the element when data is missing.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit, encouraging empty state for the "Personal Best" indicator when the user hasn't set a high score yet.
🎯 Why: Previously, the high score was completely hidden if it was 0. Showing an explicit "None yet! Set a record!" message clarifies the system state, introduces the concept of a high score to new users, and encourages engagement.
📸 Before/After: Visual text change in CLI.
♿ Accessibility: N/A - Improves general usability and clarity.

---
*PR created automatically by Jules for task [16566475145712945038](https://jules.google.com/task/16566475145712945038) started by @EiJackGH*