### PR TITLE
🎨 Palette: Comma-formatted score display in Speed Clicker

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include "utils.hpp"
 
 // Color and formatting macros for terminal output
 #define RESET     "\033[0m"
@@ -78,7 +79,7 @@ int main() {
     std::cout << CLR_CTRL << "==========================\n      SPEED CLICKER\n==========================\n" << CLR_RESET;
 
     if (highscore > 0) {
-        std::cout << " Personal Best: " << CLR_SCORE << highscore << CLR_RESET << "\n\n";
+        std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "
@@ -142,9 +143,9 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << score << CLR_RESET << " | High: " << highscore << " "
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳" : "")
+                      << (score > initialHighscore ? " NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" : "")
                       << std::flush;
             updateUI = false;
         }
@@ -155,7 +156,7 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << score << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -1,0 +1,17 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
+#include <string>
+
+inline std::string formatWithCommas(long long value) {
+    std::string s = std::to_string(value);
+    int limit = (value < 0) ? 1 : 0;
+    int insertPosition = static_cast<int>(s.length()) - 3;
+    while (insertPosition > limit) {
+        s.insert(insertPosition, ",");
+        insertPosition -= 3;
+    }
+    return s;
+}
+
+#endif // UTILS_HPP


### PR DESCRIPTION
### 🎨 Palette: Comma-formatted score display in Speed Clicker

#### 💡 What:
Introduced thousands-separator comma formatting (`1,234` instead of `1234`) for all score and high-score displays in the Speed Clicker game interface, and enhanced the "NEW BEST!" notification to display the previous record's value as context (e.g., `NEW BEST! 🥳 (was 1,500)`).

#### 🎯 Why:
Large numbers are notoriously difficult to read quickly in high-speed, real-time terminal environments. Adding thousands separators improves instant readability for players. Furthermore, providing context about what their previous high score was highlights the magnitude of their achievement and creates a more delightful experience.

#### ♿ Accessibility & Readability:
* Commas separate digits into readable thousands blocks, benefiting users with cognitive load constraints or low vision.
* Displays the previous score directly within the live HUD upon breaking a personal best to minimize memory load for the user.

---
*PR created automatically by Jules for task [11440994292985435490](https://jules.google.com/task/11440994292985435490) started by @aidasofialily-cmd*