### PR TITLE
Fix unrecognized hashFiles function in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,12 +14,13 @@ env:
 
 jobs:
   build:
-    if: hashFiles('**/*.rs') != ''
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
     - name: Build
+      if: hashFiles('**/*.rs') != ''
       run: cargo build --verbose
     - name: Run tests
+      if: hashFiles('**/*.rs') != ''
       run: cargo test --verbose


### PR DESCRIPTION
The GitHub Actions workflow 'rust.yml' was failing to validate because of an unrecognized function error: 'hashFiles' used in a job-level 'if' condition. According to the GitHub Actions context reference, 'hashFiles' is not supported at the job level because evaluations occur before checking out the repository, but it is fully supported at the step-level 'if' condition. 

We resolved this by:
1. Removing the 'if: hashFiles('**/*.rs') != ''' condition from the 'build' job level.
2. Adding 'if: hashFiles('**/*.rs') != ''' to the individual 'Build' and 'Run tests' steps in the job, which run after the repository checkout.

---
*PR created automatically by Jules for task [4980777395912205951](https://jules.google.com/task/4980777395912205951) started by @aidasofialily-cmd*