### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-19 - Explicit Empty States in CLI
+**Learning:** In terminal applications, hiding UI elements when data is empty (like a high score of 0) leaves users guessing about the system state and misses an opportunity for onboarding. Explicit, encouraging empty states improve clarity and provide immediate motivation.
+**Action:** Always provide explicit empty states for data or achievements rather than hiding the UI element, ensuring users understand the current state and what to do next.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**💡 What:** Added an explicit empty state ("None yet! Go set a record!") to the high score display when the score is 0.
**🎯 Why:** Hiding the UI element when the high score is 0 leaves new users guessing about the system state and misses an opportunity for onboarding. An explicit, encouraging message improves clarity and provides immediate motivation.
**📸 Before/After:** Before, nothing was displayed if the high score was 0. After, it explicitly shows "Personal Best: None yet! Go set a record!".
**♿ Accessibility:** Improves cognitive accessibility and onboarding by making the system state explicit rather than implicit.

---
*PR created automatically by Jules for task [631027662479828297](https://jules.google.com/task/631027662479828297) started by @EiJackGH*