### PR TITLE
🎨 Palette: prevent terminal color bleed and enhance achievement display

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,8 +144,8 @@ int main() {
 
         if (updateUI) {
             std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
-                      << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" : "")
+                      << (hardMode ? CLR_HARD "[HARD MODE]" CLR_RESET : CLR_NORM "[NORMAL MODE]" CLR_RESET)
+                      << (score > initialHighscore ? std::string(" ") + CLR_CTRL + "NEW BEST! ✨🥳" + CLR_RESET + " (was " + formatWithCommas(initialHighscore) + ")" : "")
                       << std::flush;
             updateUI = false;
         }
@@ -158,7 +158,7 @@ int main() {
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_CTRL << "Congratulations! A new personal best! ✨🥳" << CLR_RESET << " (was " << formatWithCommas(initialHighscore) << ")\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
### 🎨 Palette: Prevent Terminal Color Bleed & Polish Celebration UX

#### 💡 What
This pull request addresses terminal visual quality and user feedback loop enhancements:
1. **Resets active colors** for the mode display (`[HARD MODE]` or `[NORMAL MODE]`) by appending `CLR_RESET` right after, preventing the subsequent live text (such as "NEW BEST!") from bleeding into hard/normal mode colors.
2. **Highlights the achievement message** in the game loop with Bold Yellow (`CLR_CTRL`) and introduces extra visual flair with spark emojis (`✨`) before resetting formatting correctly.
3. **Improves final feedback visibility and context**: When a player achieves a new personal best, the congratulations message is now highlighted in Bold Yellow (`CLR_CTRL`), styled with spark emojis (`✨`), and immediately provides context by showing their previous record (e.g., `(was 1,000)`).

#### 🎯 Why
- **Color bleed** degrades CLI visual presentation and can make the terminal difficult to read or navigate after exit.
- **Immediate context** on milestones increases player retention and satisfaction by showing them *how much* they improved, rather than just stating *that* they improved.
- Adding sparkle emojis and highlights heightens the sense of accomplishment, delivering small moments of delight.

#### ♿ Accessibility
- Cleans up stray formatting / active console color bleed.
- Emphasizes personal milestones clearly.

---
*PR created automatically by Jules for task [2408851911101407865](https://jules.google.com/task/2408851911101407865) started by @aidasofialily-cmd*