### PR TITLE
🎨 Palette: Add empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-10-25 - Provide explicit empty states
+**Learning:** When displaying dynamic data or achievements (like high scores), hiding the entire UI block when data is empty leaves the user without context about what they can achieve.
+**Action:** Always provide explicit, encouraging empty states (e.g., "None yet! Start clicking!") rather than simply omitting the UI element when the value is 0 or empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Start clicking!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
**💡 What:** Added an explicit empty state to the highscore display ("None yet! Start clicking!") instead of hiding the component entirely when the score is 0.
**🎯 Why:** When the UI simply hides data that is 0 or unachieved, the user has no context that there is a highscore feature available to them. Showing an encouraging empty state clarifies the system state and gamifies the onboarding experience.
**📸 Before/After:** Before, the line didn't appear. After, it shows "Personal Best: None yet! Start clicking!".
**♿ Accessibility:** N/A (Standard CLI text update, improving cognitive accessibility via context).

---
*PR created automatically by Jules for task [15889245681482306852](https://jules.google.com/task/15889245681482306852) started by @EiJackGH*