### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-24 - Explicit Empty States in CLI
+**Learning:** Hiding UI elements when data is empty leaves users guessing about the system state and misses an opportunity for onboarding. Providing an explicit empty state clarifies the interface and encourages engagement.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty, to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Start clicking!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Replaced the hidden high score display condition with an explicit empty state message ("None yet! Start clicking!") when the high score is 0.
🎯 **Why**: Hiding UI elements when data is empty leaves users guessing about the system state. Providing an explicit empty state clarifies the interface and encourages initial engagement.
📸 **Before/After**: 
  - Before: No "Personal Best" text shown on first launch.
  - After: Shows "Personal Best: None yet! Start clicking!" on first launch.
♿ **Accessibility**: Improves cognitive accessibility by explicitly confirming the initial state to the user rather than relying on absence of information.

---
*PR created automatically by Jules for task [4365340228737410738](https://jules.google.com/task/4365340228737410738) started by @EiJackGH*