### PR TITLE
🎨 Palette: Add visual flair and correct formatting spill for personal best achievement notification

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ int main() {
         if (updateUI) {
             std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" : "")
+                      << (score > initialHighscore ? " " CLR_CTRL "✨ NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" CLR_RESET : CLR_RESET)
                       << std::flush;
             updateUI = false;
         }


### PR DESCRIPTION
### 💡 What
This pull request adds extra visual polish and visual flair to the Speed Clicker CLI game's high score achievement notifications. 

### 🎯 Why
When a player achieves a new personal best, displaying the achievement with prominent color formatting (`CLR_CTRL`, bold yellow) and emojis adds a sense of accomplishment and visual delight. In addition, resetting the terminal style dynamically prevents styling and color bleed from spilling into the rest of the terminal output if the achievement condition is not met.

### ♿ Accessibility
Highlights achievement metrics with optimal color differentiation (`CLR_CTRL`) to enhance readability in terminal-based environments.

---
*PR created automatically by Jules for task [5577633756903740002](https://jules.google.com/task/5577633756903740002) started by @aidasofialily-cmd*