### PR TITLE
🎨 Palette: Add explicit empty state for personal best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-05-18 - Explicit Empty States in CLI
+**Learning:** Hiding UI elements like a personal best score when no data exists (e.g., score is 0) can leave new users confused about the system's capabilities.
+**Action:** Always provide explicit, encouraging empty states (like "None yet! Play to set a record!") to clarify the system state and improve user onboarding, even in minimal CLI applications.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
- **What**: Added an explicit empty state message for the Personal Best score when it is 0.
- **Why**: To improve user onboarding by clearly showing that a high score feature exists and encouraging them to play, rather than just hiding the element when empty.
- **Before/After**: Before, the "Personal Best" line was completely hidden if the score was 0. After, it shows "None yet! Play to set a record!".
- **Accessibility**: Clarifies the system state for all users instead of relying on an invisible absence of information.

---
*PR created automatically by Jules for task [6446861845123079360](https://jules.google.com/task/6446861845123079360) started by @EiJackGH*