### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-24 - Explicit Empty States for Achievements
+**Learning:** Hiding UI elements (like high scores) when they are zero or empty leaves first-time users guessing about the system's capabilities. Providing an explicit, encouraging empty state clarifies the goal and improves onboarding.
+**Action:** Always provide encouraging placeholder text or empty states for data/achievements rather than conditionally hiding the UI elements.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state for the "Personal Best" section in the game.
🎯 Why: Conditionally hiding the high score section when it is 0 leaves first-time users guessing about the system's capabilities. A clear empty state clarifies the goal and improves onboarding.
📸 Before/After: Visual change in the CLI output when running for the first time.
♿ Accessibility: Improves cognitive accessibility by providing clear expectations for first-time users.

---
*PR created automatically by Jules for task [16940233144900360540](https://jules.google.com/task/16940233144900360540) started by @EiJackGH*