### PR TITLE
🎨 Palette: Add explicit empty state for Personal Best

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-24 - Explicit Empty States in CLI
+**Learning:** Hiding UI elements like achievements when they are empty creates ambiguity. Providing explicit, encouraging empty states clarifies system state and improves onboarding for first-time users.
+**Action:** Always provide encouraging empty states for data or achievements rather than hiding the UI element entirely.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an encouraging empty state message ("None yet! Go set a record!") when the highscore is 0.
🎯 Why: To clarify system state and improve user onboarding, as hiding the UI element when empty causes ambiguity for first-time players.
📸 Before/After: Before, no highscore text was displayed for new users. After, they see an encouraging message.
♿ Accessibility: Improves cognitive accessibility by explicitly confirming the state rather than relying on absence of information.

---
*PR created automatically by Jules for task [9521814617608310575](https://jules.google.com/task/9521814617608310575) started by @EiJackGH*