### PR TITLE
🎨 Palette: Add encouraging empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-28 - Explicit Empty States in CLI
+**Learning:** In CLI applications, hiding UI elements when data is empty (like a high score of 0) can confuse new users. Explicit, encouraging empty states (e.g., "None yet! Go set a record!") clarify the system state and improve user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit, encouraging empty state for the high score display when the score is 0.
🎯 Why: Previously, if the high score was 0, the entire line was hidden, which could leave new users unaware that high scores are tracked. An encouraging message ("None yet! Go set a record!") clarifies the system state and improves the onboarding experience.
📸 Before: (Hidden line)
📸 After: `Personal Best: None yet! Go set a record!`
♿ Accessibility: Improves clarity and provides explicit system status feedback for all users.

---
*PR created automatically by Jules for task [498510414770196766](https://jules.google.com/task/498510414770196766) started by @EiJackGH*