### PR TITLE
🎨 Palette: Add Beautiful Post-Game Metric Summary

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-06-01 - Post-Game Metric Summaries in CLI Clickers
+**Learning:** In clicker or high-frequency input games, players crave analytical feedback. Simply showing a final score is less satisfying than presenting performance metrics like manual clicks, session duration, and clicks per second (CPS). Placing these inside a visually distinct "Game Over Summary" block provides immediate, gratifying closure.
+**Action:** Always capture input events with timestamps to compute and present detailed session statistics (such as average frequency or efficiency) in terminal game summaries.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include <cstdio>
 #include "utils.hpp"
 
 // Color and formatting macros for terminal output
@@ -114,6 +115,9 @@ int main() {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
+    auto game_start_time = std::chrono::steady_clock::now();
+    long long manualClicks = 0;
+
     auto last_tick = std::chrono::steady_clock::now();
     bool updateUI = true;
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
@@ -128,6 +132,7 @@ int main() {
             if (input == 'h') hardMode = !hardMode;
             else {
                 score++;
+                manualClicks++;
                 if (score > highscore) highscore = score;
             }
             updateUI = true;
@@ -156,10 +161,22 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+
+    auto game_end_time = std::chrono::steady_clock::now();
+    double duration_sec = std::chrono::duration_cast<std::chrono::milliseconds>(game_end_time - game_start_time).count() / 1000.0;
+    double cps = (duration_sec > 0.0) ? (manualClicks / duration_sec) : 0.0;
+
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << CLR_CTRL << "Congratulations! A new personal best! 🏆✨" << CLR_RESET << "\n";
     }
+
+    std::cout << "\n" << CLR_CTRL << "=== GAME OVER SUMMARY ===" << CLR_RESET << "\n";
+    std::printf(" Session Duration : %s%.2f%s seconds\n", CLR_SCORE, duration_sec, CLR_RESET);
+    std::printf(" Manual Clicks    : %s%s%s\n", CLR_SCORE, formatWithCommas(manualClicks).c_str(), CLR_RESET);
+    std::printf(" Average CPS      : %s%.2f%s clicks/sec\n", CLR_SCORE, cps, CLR_RESET);
+    std::cout << CLR_CTRL << "=========================" << CLR_RESET << "\n\n";
+
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;
     return 0;


### PR DESCRIPTION
### 🎨 Palette: Delightful Post-Game Metrics Dashboard

#### 💡 What
Added a post-game performance metrics dashboard that displays upon game completion or manual exit:
- **Session Duration:** Time active in game in seconds (formatted to 2 decimal places).
- **Manual Clicks:** Total keystrokes input by the player during gameplay (comma-formatted).
- **Average Clicks Per Second (CPS):** Overall click rate of manual inputs.
- Styled using existing ANSI color macros (`CLR_SCORE` and `CLR_CTRL`) to match the existing game theme.

#### 🎯 Why
In a speed-based clicker game, the primary source of engagement and replayability is personal performance analytics. Displaying a simple score without contextual click-frequency metrics misses an opportunity for player gratification. By tracking manual inputs and elapsed session duration, we render a highly satisfying performance card.

#### ♿ Accessibility & Visual Polish
- Uses clean spacing and clear labeling to form a legible and delightful console UI layout.
- Integrates with signal handlers and normal termination paths to ensure terminal cursor restoration is unaffected.
- Kept the implementation extremely lightweight and robust (less than 25 net lines of code addition, fitting the Palette PR footprint limits).
- Documented in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [2413756911359959218](https://jules.google.com/task/2413756911359959218) started by @aidasofialily-cmd*