### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-10-24 - Explicit Empty States for Achievements
+**Learning:** Hiding achievement UI elements (like high scores) when empty leaves new users without a clear goal or understanding of the system's capabilities.
+**Action:** Always provide explicit, encouraging empty states for data or achievements to clarify system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state ("None yet! Set a record!") for the Personal Best display when the high score is 0.
🎯 **Why:** To prevent the achievement UI from being completely hidden for first-time users, which leaves them without a clear goal or understanding of the system's capabilities.
📸 **Before/After:** The "Personal Best" section is now always visible, even when the user hasn't set a record yet.
♿ **Accessibility:** Improves cognitive accessibility by providing explicit system status and clear user goals from the very first interaction.

---
*PR created automatically by Jules for task [12747116164830181584](https://jules.google.com/task/12747116164830181584) started by @EiJackGH*