### PR TITLE
🎨 Palette: Add Game Over session stats summary

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,7 @@ int main() {
     long long highscore = load_highscore();
     long long initialHighscore = highscore;
     long long score = 0;
+    long long manual_clicks = 0;
     bool hardMode = false;
     char input;
 
@@ -114,6 +115,7 @@ int main() {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
+    auto game_start_time = std::chrono::steady_clock::now();
     auto last_tick = std::chrono::steady_clock::now();
     bool updateUI = true;
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
@@ -128,6 +130,7 @@ int main() {
             if (input == 'h') hardMode = !hardMode;
             else {
                 score++;
+                manual_clicks++;
                 if (score > highscore) highscore = score;
             }
             updateUI = true;
@@ -151,12 +154,29 @@ int main() {
         }
     }
 
+    auto game_end_time = std::chrono::steady_clock::now();
+
     if (score > initialHighscore) {
         save_highscore(score);
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
+
+    auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(game_end_time - game_start_time).count();
+    double seconds = duration_ms / 1000.0;
+    double cps = seconds > 0.0 ? (static_cast<double>(manual_clicks) / seconds) : 0.0;
+    long long duration_dec = (duration_ms / 100) % 10;
+    long long duration_sec = duration_ms / 1000;
+    long long cps_int = static_cast<long long>(cps);
+    long long cps_dec = static_cast<long long>(cps * 10) % 10;
+
+    std::cout << "\n\n" << CLR_CTRL << "==========================\n      SESSION SUMMARY\n==========================\n" << CLR_RESET;
+    std::cout << " Play Time:     " << CLR_SCORE << duration_sec << "." << duration_dec << "s" << CLR_RESET << "\n";
+    std::cout << " Manual Clicks: " << CLR_SCORE << formatWithCommas(manual_clicks) << CLR_RESET << "\n";
+    std::cout << " Avg CPS:       " << CLR_SCORE << cps_int << "." << cps_dec << " clicks/s" << CLR_RESET << "\n";
+    std::cout << CLR_CTRL << "==========================\n" << CLR_RESET << "\n";
+
+    std::cout << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
## Session Summary Micro-UX Enhancement

### 💡 What
This pull request implements a delightful end-of-game session summary statistics window when the Speed Clicker terminal game is closed. It logs the exact millisecond duration of the gameplay session along with the count of actual manual keystrokes made by the user.

### 🎯 Why
Terminal-based clicker games are highly engaging, but without post-game analytics, players miss immediate feedback on their speed performance. Presenting total play duration, total manual clicks, and a calculated Clicks Per Second (CPS) rate provides a satisfying gameplay report, encouraging replayability and competitive score-chasing.

### ♿ Accessibility & Visual Polish
- Uses the project's existing ANSI color macros (`CLR_CTRL`, `CLR_SCORE`, and `CLR_RESET`) to construct a matching double-bordered summary box.
- Keeps terminal styles clean and prevents trailing artifacts.
- Safely handles division by zero and formats output with sub-second precision without requiring float-manipulation header bloat.

---
*PR created automatically by Jules for task [10084737377730871292](https://jules.google.com/task/10084737377730871292) started by @aidasofialily-cmd*