### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2025-02-14 - Explicit Empty States in CLI
+**Learning:** Hiding UI elements like high scores when empty can leave new users confused about the system state. Providing an explicit, encouraging empty state (e.g., "None yet. Time to set one!") clarifies the goal and improves onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet. Time to set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state ("None yet. Time to set one!") for the highscore display instead of simply omitting the "Personal Best" section when the high score is 0.
🎯 Why: New users might not realize the game tracks high scores if the UI completely hides the element. An explicit empty state clarifies the system state and gives players an immediate onboarding goal.
📸 Before/After: Before, a new game simply showed "Controls". After, it shows "Personal Best: None yet. Time to set one!"
♿ Accessibility: Improves cognitive accessibility by explicitly stating the absence of a record rather than requiring the user to deduce it from a missing UI element.

---
*PR created automatically by Jules for task [12268892966759470171](https://jules.google.com/task/12268892966759470171) started by @EiJackGH*