### PR TITLE
🎨 Palette: Real-time CPS and Game Over Summary

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,8 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include <iomanip>
+#include <sstream>
 #include "utils.hpp"
 
 // Color and formatting macros for terminal output
@@ -114,6 +116,9 @@ int main() {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
+    auto game_start = std::chrono::steady_clock::now();
+    long long manualClicks = 0;
+
     auto last_tick = std::chrono::steady_clock::now();
     bool updateUI = true;
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
@@ -128,6 +133,7 @@ int main() {
             if (input == 'h') hardMode = !hardMode;
             else {
                 score++;
+                manualClicks++;
                 if (score > highscore) highscore = score;
             }
             updateUI = true;
@@ -143,7 +149,12 @@ int main() {
         }
 
         if (updateUI) {
-            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
+            double elapsed_sec = std::chrono::duration_cast<std::chrono::milliseconds>(now - game_start).count() / 1000.0;
+            double cps = (elapsed_sec > 0.0) ? (manualClicks / elapsed_sec) : 0.0;
+            std::stringstream cps_ss;
+            cps_ss << std::fixed << std::setprecision(1) << cps;
+
+            std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " | CPS: " << cps_ss.str() << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
                       << (score > initialHighscore ? " NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" : "")
                       << std::flush;
@@ -156,7 +167,20 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
+    auto game_end = std::chrono::steady_clock::now();
+    double total_elapsed_sec = std::chrono::duration_cast<std::chrono::milliseconds>(game_end - game_start).count() / 1000.0;
+    double avg_cps = (total_elapsed_sec > 0.0) ? (manualClicks / total_elapsed_sec) : 0.0;
+    std::stringstream avg_cps_ss, duration_ss;
+    avg_cps_ss << std::fixed << std::setprecision(1) << avg_cps;
+    duration_ss << std::fixed << std::setprecision(1) << total_elapsed_sec;
+
+    std::cout << "\n\n" << CLR_CTRL << "==========================\n        GAME OVER\n==========================\n" << CLR_RESET;
+    std::cout << " Final Score: " << CLR_SCORE << formatWithCommas(score) << CLR_RESET << "\n";
+    std::cout << " Game Duration: " << CLR_SCORE << duration_ss.str() << " seconds" << CLR_RESET << "\n";
+    std::cout << " Manual Clicks: " << CLR_SCORE << formatWithCommas(manualClicks) << CLR_RESET << "\n";
+    std::cout << " Average CPS: " << CLR_SCORE << avg_cps_ss.str() << " clicks/sec" << CLR_RESET << "\n";
+    std::cout << CLR_CTRL << "==========================\n" << CLR_RESET;
+
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }


### PR DESCRIPTION
This pull request adds an informative real-time Clicks Per Second (CPS) tracker directly in the CLI game's active HUD and delivers a beautiful post-game statistics summary upon exit. 

### 💡 What
1. **Real-time CPS Tracking**: Calculated in real-time as `manual clicks / elapsed duration (seconds)`.
2. **Game Over Summary**: Upon quitting or game-over, a polished console box appears highlighting total duration, manual clicks, final score, and average CPS performance.

### 🎯 Why
In simple clicker games, real-time tactile feedback and performance retrospectives keep the gameplay engaging and reward the player's clicking effort. Providing clear metrics on their clicking speed elevates the game's UX immensely.

### ♿ Accessibility & Visual Polish
- Uses the unified visual style established in the repo's macro palettes (`CLR_CTRL`, `CLR_SCORE`, etc.) to draw a structured summary box.
- Preserves all raw terminal restoration and cursor-hiding logic.

---
*PR created automatically by Jules for task [479992179875477200](https://jules.google.com/task/479992179875477200) started by @aidasofialily-cmd*