### PR TITLE
🎨 Palette: Add empty state for new players

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-28 - Explicit Empty States for Onboarding
+**Learning:** In applications with scoring or progress tracking, simply hiding the tracking element when empty (e.g., a score of 0) misses an opportunity to guide and motivate the user. Explicit empty states provide context and a clear "call to action".
+**Action:** Always provide encouraging empty states for data or achievements to clarify system state and improve user onboarding, rather than just hiding the UI element.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
* **What:** Added an explicit "None yet! Play to set a record!" message for first-time players when their high score is 0.
* **Why:** Previously, the UI silently omitted the "Personal Best" section for new players. An explicit empty state provides a warmer onboarding experience and immediately sets a clear goal.
* **Before/After:** No message vs. "None yet! Play to set a record!".
* **Accessibility:** Improves clarity of system state for all users.

---
*PR created automatically by Jules for task [6365729412096161548](https://jules.google.com/task/6365729412096161548) started by @EiJackGH*