### PR TITLE
🎨 Palette: Add Game Over stats and style improvements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,9 @@ int main() {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
-    auto last_tick = std::chrono::steady_clock::now();
+    auto game_start = std::chrono::steady_clock::now();
+    auto last_tick = game_start;
+    long long manualClicks = 0;
     bool updateUI = true;
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     while (true) {
@@ -128,6 +130,7 @@ int main() {
             if (input == 'h') hardMode = !hardMode;
             else {
                 score++;
+                manualClicks++;
                 if (score > highscore) highscore = score;
             }
             updateUI = true;
@@ -145,7 +148,7 @@ int main() {
         if (updateUI) {
             std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" : "")
+                      << (score > initialHighscore ? std::string(" ") + CLR_CTRL + "NEW BEST! ✨🥳 (was " + formatWithCommas(initialHighscore) + ")" + CLR_RESET : "")
                       << std::flush;
             updateUI = false;
         }
@@ -156,11 +159,23 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
+    auto game_end = std::chrono::steady_clock::now();
+    double duration = std::chrono::duration_cast<std::chrono::milliseconds>(game_end - game_start).count() / 1000.0;
+    double cps = duration > 0 ? manualClicks / duration : 0.0;
+
+    std::cout << "\n\n" << CLR_CTRL << "=================================\n           GAME OVER\n=================================\n" << CLR_RESET;
+    std::cout << " Final Score:  " << CLR_SCORE << formatWithCommas(score) << CLR_RESET << "\n";
+    std::cout << " Total Clicks: " << CLR_SCORE << formatWithCommas(manualClicks) << CLR_RESET << "\n";
+    std::cout << " Duration:     " << CLR_SCORE << std::fixed;
+    std::cout.precision(1);
+    std::cout << duration << "s" << CLR_RESET << "\n";
+    std::cout << " Average CPS:  " << CLR_SCORE << cps << CLR_RESET << "\n";
+    std::cout << CLR_CTRL << "=================================\n" << CLR_RESET;
+
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "\n" << CLR_CTRL << "✨ Congratulations! A new personal best! ✨" << CLR_RESET << "\n";
     }
-    std::cout << "Thanks for playing!\n";
+    std::cout << "\nThanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;
     return 0;
 }


### PR DESCRIPTION
### 🎨 Palette: Detailed Game Over Summary & Highlight Polish

#### 💡 What:
- Tracks `manualClicks` (only counting actual manual key presses, excluding 'h' and 'q') and the active gameplay duration (`game_start` to `game_end`).
- Computes the average **Clicks Per Second (CPS)** performance upon exiting the game.
- Implements a stylized "GAME OVER" summary screen reporting Final Score, Total Clicks, Duration, and average CPS.
- Polishes the live HUD score and milestone notification to utilize bold yellow highlighting with decorative emojis (`NEW BEST! ✨🥳`), explicitly terminating formatting via `CLR_RESET` to avoid any style bleeding.

#### 🎯 Why:
Providing rich post-game statistics such as manual clicks count, gameplay duration, and a calculated Clicks Per Second metric transforms raw clicker actions into a delightful, game-like experience with immediate post-run tactile feedback. Polishing the color scheme ensures styling does not bleed into the rest of the user's terminal session, improving overall console UX.

#### ♿ Accessibility & Style:
- Utilizes consistent color mapping with the existing game palette (`CLR_CTRL` / `CLR_SCORE`).
- Clears styling immediately following prints via reset markers to safeguard general terminal environments.
- High-score notification sparkles provide intuitive and delightful feedback on personal achievements.

---
*PR created automatically by Jules for task [4547181891898188506](https://jules.google.com/task/4547181891898188506) started by @aidasofialily-cmd*