### PR TITLE
🎨 Palette: Add encouraging empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-25 - Encouraging Empty States in CLI
+**Learning:** Hiding UI elements when data or achievements are empty can leave users confused about system state. Providing explicit, encouraging empty states clarifies the system state and improves user onboarding.
+**Action:** Always provide explicit, encouraging empty states for data or achievements in CLI applications rather than hiding the UI element.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet. Time to set one!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state message when the user's highscore is zero.
🎯 Why: Improves user onboarding and clarifies system state instead of hiding the personal best entirely.
📸 Before/After: Before, it displayed nothing if the score was 0. Now, it displays "None yet. Time to set one!".
♿ Accessibility: Reduces cognitive load and provides clear feedback for first-time players.

---
*PR created automatically by Jules for task [10470458114893526568](https://jules.google.com/task/10470458114893526568) started by @EiJackGH*