### PR TITLE
🎨 Palette: Polished Game Over Summary Screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include <iomanip>
 #include "utils.hpp"
 
 // Color and formatting macros for terminal output
@@ -114,7 +115,9 @@ int main() {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
-    auto last_tick = std::chrono::steady_clock::now();
+    long long manualClicks = 0;
+    auto game_start_time = std::chrono::steady_clock::now();
+    auto last_tick = game_start_time;
     bool updateUI = true;
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     while (true) {
@@ -127,6 +130,7 @@ int main() {
             if (read(STDIN_FILENO, &input, 1) <= 0 || input == 'q') break;
             if (input == 'h') hardMode = !hardMode;
             else {
+                manualClicks++;
                 score++;
                 if (score > highscore) highscore = score;
             }
@@ -151,14 +155,29 @@ int main() {
         }
     }
 
+    auto game_end_time = std::chrono::steady_clock::now();
+    double duration_sec = std::chrono::duration_cast<std::chrono::milliseconds>(game_end_time - game_start_time).count() / 1000.0;
+    double cps = duration_sec > 0.0 ? (static_cast<double>(manualClicks) / duration_sec) : 0.0;
+
     if (score > initialHighscore) {
         save_highscore(score);
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-    std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
+    std::cout << "\n\n" << CLR_CTRL << "======================================\n"
+              << "              GAME OVER\n"
+              << "======================================\n" << CLR_RESET;
+    std::cout << " " << CLR_SCORE << "Final Score:    " << formatWithCommas(score) << CLR_RESET << "\n";
+    std::cout << " Total Clicks:   " << CLR_NORM << formatWithCommas(manualClicks) << CLR_RESET << "\n";
+    std::cout << " Play Time:      " << CLR_NORM << std::fixed << std::setprecision(2) << duration_sec << "s" << CLR_RESET << "\n";
+    std::cout << " Average CPS:    " << CLR_NORM << std::fixed << std::setprecision(2) << cps << " clicks/s" << CLR_RESET << "\n";
+    std::cout << CLR_CTRL << "======================================\n" << CLR_RESET;
+
     if (score > initialHighscore) {
-        std::cout << "Congratulations! A new personal best!\n";
+        std::cout << "\n ✨ " << CLR_CTRL << "NEW BEST! 🥳 " << CLR_RESET << "You beat your old score of " << CLR_SCORE << formatWithCommas(initialHighscore) << CLR_RESET << "!\n";
+        std::cout << " " << CLR_NORM << "Congratulations! A new personal best!\n\n" << CLR_RESET;
+    } else {
+        std::cout << "\n" << CLR_SCORE << "Personal Best: " << formatWithCommas(highscore) << CLR_RESET << "\n\n";
     }
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;


### PR DESCRIPTION
Added a polished Game Over summary dashboard to the terminal UI of the Speed Clicker game. It tracks the duration of the gameplay session, total manual keypress clicks, and calculates/displays the average CPS (Clicks Per Second) with precise double formatting. If a player achieves a new personal best, the UI displays a cheerful visual celebration highlighting the achievement, and if not, it friendly displays their current personal best. Tested compilation and ran UX regression checks.

---
*PR created automatically by Jules for task [4478318463066628508](https://jules.google.com/task/4478318463066628508) started by @aidasofialily-cmd*