### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-07-30 - Explicit Empty States for Achievements
+**Learning:** Hiding achievement data (like a high score) when it is zero or unset leaves new users wondering if the feature exists or is broken.
+**Action:** Always provide an explicit, encouraging empty state (e.g., "None yet" or "0") to clarify system state and improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet" << CLR_RESET << " (Play to set a record!)\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit empty state ("None yet") for the Personal Best score display instead of hiding it entirely when the score is zero.
🎯 Why: To clarify the system state for new users and explicitly encourage them to play to set a record. Hiding achievement data when zero leaves users wondering if the feature exists.
📸 Before/After: 
Before: Personal Best line was entirely hidden on first play.
After: "Personal Best: None yet (Play to set a record!)"
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [2047500003781448605](https://jules.google.com/task/2047500003781448605) started by @EiJackGH*