### PR TITLE
🎨 Palette: Add encouraging empty state for High Score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2025-01-25 - Encouraging Empty States in CLI Applications
+**Learning:** When displaying achievements or stats in a CLI application (like a High Score), showing nothing when the value is 0 creates an unengaging "empty" state. First-time users need clear visual feedback to understand the goal. Providing an explicit, encouraging empty state (e.g., "None yet! Set a record!") rather than hiding the element improves onboarding and clarifies system intent.
+**Action:** Always provide explicit, encouraging empty states for data or achievements in CLI applications, rather than omitting the UI element entirely.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit "None yet! Set a record!" message when the user's high score is 0, rather than leaving the space blank.
🎯 Why: A blank space fails to communicate that a high score is even being tracked. Providing an encouraging empty state improves the onboarding experience for first-time players by making the goal clear.
📸 Before/After: Before, a first-time player would see no high score indicator. Now, they see "Personal Best: None yet! Set a record!".
♿ Accessibility: Improves cognitive accessibility by clearly communicating system state and user goals without relying on implicit knowledge.

---
*PR created automatically by Jules for task [10601971270346083706](https://jules.google.com/task/10601971270346083706) started by @EiJackGH*