### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-05-18 - CLI Empty States
+**Learning:** In CLI applications, omitting data sections when empty (like a high score of 0) can leave new users confused about the system state or goals.
+**Action:** Always provide explicit, encouraging empty states (e.g., "None yet! Let's set a record!") to clarify the interface and improve onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Let's set a record! 🚀" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit, encouraging empty state for the high score display when a user plays for the first time (score = 0).
🎯 **Why:** To clarify the system state and provide a welcoming onboarding experience. Previously, the high score section was simply hidden if it was 0, which could leave new players confused about whether high scores were tracked at all.
📸 **Before/After:**
*Before:*
```
Controls:
 [h] Toggle Hard Mode
```
*After:*
```
Personal Best: None yet! Let's set a record! 🚀

Controls:
 [h] Toggle Hard Mode
```
♿ **Accessibility:** Improves cognitive accessibility by explicitly stating the game's state (no high score yet) rather than relying on the user to infer it from missing information.

---
*PR created automatically by Jules for task [6017250339676641763](https://jules.google.com/task/6017250339676641763) started by @EiJackGH*