### PR TITLE
🎨 Palette: Add explicit empty state for initial high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-08-02 - Explicit Empty States for Achievements
+**Learning:** Hiding data like high scores when they are zero removes a motivational target for new players. An explicit empty state clarifies the system state and improves onboarding.
+**Action:** Provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ highscore.txt
 
 # Persistent data
 highscore.txt
+venv/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Added an explicit empty state message ("None yet! Go set a record!") to the Personal Best display when the user's high score is zero.

🎯 **Why**: Previously, the application silently hid the high score UI if the user had never set a record. Hiding data like high scores when they are zero removes a motivational target for new players. An explicit empty state clarifies the system state and improves onboarding.

📸 **Before/After**: (CLI UI change)
- Before (Initial Launch): (No Personal Best section displayed)
- After (Initial Launch): `Personal Best: None yet! Go set a record!`

♿ **Accessibility**: Improves clarity and context for new users by explicitly stating the current state of achievements.

---
*PR created automatically by Jules for task [10935761611525324617](https://jules.google.com/task/10935761611525324617) started by @EiJackGH*