### PR TITLE
🎨 Palette: Add visual flair and color reset to live HUD high score celebration

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ int main() {
         if (updateUI) {
             std::cout << "\r" ERASE_LINE << CLR_SCORE << "Score: " << formatWithCommas(score) << CLR_RESET << " | High: " << formatWithCommas(highscore) << " "
                       << (hardMode ? CLR_HARD "[HARD MODE]" : CLR_NORM "[NORMAL MODE]")
-                      << (score > initialHighscore ? " NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" : "")
+                      << (score > initialHighscore ? std::string(" ") + CLR_CTRL + "✨ NEW BEST! 🥳 (was " + formatWithCommas(initialHighscore) + ")" + CLR_RESET : CLR_RESET)
                       << std::flush;
             updateUI = false;
         }


### PR DESCRIPTION
### 🎨 Palette: Delightful Personal Best Highlighting in Speed Clicker Game

#### 💡 What
- Colored the "NEW BEST!" high-score indicator in the game's live HUD with Bold Yellow (`CLR_CTRL`).
- Added a visual flair star emoji (`✨ NEW BEST! 🥳`) to celebrate reaching a new high score.
- Fixed an ANSI color bleed bug where the text colors from Normal/Hard mode indicators could leak into the subsequent terminal lines by explicitly outputting `CLR_RESET` when a new high score is not active.

#### 🎯 Why
- Celebrating milestones visually in terminal games enhances players' tactile reward.
- Consistent application of ANSI resets prevents visual clutter and unexpected styling in users' terminals after the application exits or prints subsequent lines.

#### ♿ Accessibility / UX Highlights
- Immediate, prominent feedback using established theme color codes.
- High-contrast, clean visual separation between standard telemetry and achievement highlights.

---
*PR created automatically by Jules for task [16715271793790726423](https://jules.google.com/task/16715271793790726423) started by @aidasofialily-cmd*