### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2024-05-18 - Explicit Empty States
+**Learning:** Providing explicit, encouraging empty states clarifies the system state and improves user onboarding compared to completely hiding the element when data (e.g., highscore) is zero.
+**Action:** Always show an encouraging empty state instead of hiding UI elements for initial states.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set a score!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit, encouraging empty state for the highscore display when the score is 0.
🎯 Why: Previously, the highscore UI was completely hidden when the score was 0. Showing an explicit empty state ("None yet! Play to set a score!") clarifies system state and improves onboarding.
📸 Before/After: Before, the "Personal Best" line was entirely missing for new players. After, it displays an encouraging message to start playing.
♿ Accessibility: Improves cognitive accessibility by explicitly communicating the system state rather than relying on the user to infer meaning from missing UI elements.

---
*PR created automatically by Jules for task [7909055945110401258](https://jules.google.com/task/7909055945110401258) started by @EiJackGH*