### PR TITLE
🎨 Palette: Game Over Summary Screen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include <iomanip>
 #include "utils.hpp"
 
 // Color and formatting macros for terminal output
@@ -114,6 +115,8 @@ int main() {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tcflush(STDIN_FILENO, TCIFLUSH);
 
+    auto game_start_time = std::chrono::steady_clock::now();
+    long long manualClicks = 0;
     auto last_tick = std::chrono::steady_clock::now();
     bool updateUI = true;
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
@@ -128,6 +131,7 @@ int main() {
             if (input == 'h') hardMode = !hardMode;
             else {
                 score++;
+                manualClicks++;
                 if (score > highscore) highscore = score;
             }
             updateUI = true;
@@ -156,10 +160,22 @@ int main() {
     }
 
     tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+
+    auto game_end_time = std::chrono::steady_clock::now();
+    double duration = std::chrono::duration_cast<std::chrono::milliseconds>(game_end_time - game_start_time).count() / 1000.0;
+    double cps = (duration > 0.0) ? (manualClicks / duration) : 0.0;
+
     std::cout << "\n\n" << CLR_SCORE << "Final Score: " << formatWithCommas(score) << CLR_RESET << "\n";
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }
+
+    std::cout << CLR_CTRL << "\n=================================\n       GAME OVER SUMMARY\n=================================\n" << CLR_RESET;
+    std::cout << " Session Duration : " << std::fixed << std::setprecision(1) << duration << "s\n";
+    std::cout << " Total Clicks     : " << formatWithCommas(manualClicks) << "\n";
+    std::cout << " Average CPS      : " << std::fixed << std::setprecision(2) << cps << "\n";
+    std::cout << CLR_CTRL << "=================================\n" << CLR_RESET << "\n";
+
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;
     return 0;


### PR DESCRIPTION
Add game over statistics summary screen.

This micro-UX improvement tracks:
- Total session duration (formatted with 1 decimal precision)
- Total clicks (comma-formatted)
- Average clicks per second (CPS)

This provides users with immediate, satisfying performance metrics upon exiting the game.

---
*PR created automatically by Jules for task [14146226409198568430](https://jules.google.com/task/14146226409198568430) started by @aidasofialily-cmd*