### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-08-04 - Explicit Empty States in CLI
+**Learning:** In CLI applications, hiding UI elements when data (like a high score) is empty can confuse users about the system state. Providing an explicit, encouraging empty state clarifies expectations and improves onboarding.
+**Action:** Always provide explicit empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state ("None yet! Play to set a record!") to the high score display when the player's personal best is zero.
🎯 **Why:** Hiding the "Personal Best" UI element entirely when no record exists can confuse users about whether the feature exists or is broken. An explicit empty state clarifies the system state and encourages initial engagement.
📸 **Before/After:**
Before: [Nothing displayed if `highscore == 0`]
After: `Personal Best: None yet! Play to set a record!`
♿ **Accessibility:** Improves cognitive accessibility by providing clear, immediate context about the application's state, reducing ambiguity for new users.

---
*PR created automatically by Jules for task [12035230978098729381](https://jules.google.com/task/12035230978098729381) started by @EiJackGH*