### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,6 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+## 2026-08-05 - Explicit Empty States for Achievements
+**Learning:** Users benefit from explicit empty states (e.g., "None yet!") for achievements instead of hiding the UI element, as it clarifies system state and provides onboarding encouragement.
+**Action:** Always provide explicit, encouraging empty states for data or achievements rather than hiding the UI element when empty.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Start clicking!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
- What: Added an explicit empty state for the personal best score ("None yet! Start clicking!") instead of hiding the UI element.
- Why: To clarify system state and improve user onboarding.
- Before/After: Visual change in the console output.
- Accessibility: Clarifies the initial state for better comprehension.

---
*PR created automatically by Jules for task [12568462772653220783](https://jules.google.com/task/12568462772653220783) started by @EiJackGH*