### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2026-08-06 - Explicit Empty States in CLI
+**Learning:** In terminal applications, displaying a value of 0 or hiding a section entirely when data is absent (like a high score) can leave new users confused about the system's state or the feature's existence. An explicit empty state (e.g., "None yet! Play to set a record!") provides immediate clarity and encourages engagement.
+**Action:** Always provide explicit, encouraging text for empty data states in CLI applications rather than hiding the element or showing '0'.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
Added an encouraging empty state for the High Score display when a player starts the game for the first time.

💡 What: Added an `else` condition to the `highscore > 0` check in `src/main.cpp` to display a helpful empty state message instead of nothing.
🎯 Why: Previously, if the user had no high score, the application provided no feedback or mention of a personal best, which was poor first-time UX. An explicit empty state clarifies the system state and encourages engagement.
📸 Before/After: The terminal now displays "Personal Best: None yet! Play to set a record!" for new players, using existing color formatting (`CLR_SCORE`).
♿ Accessibility: Improves cognitive accessibility by explicitly clarifying the system state for new users, removing ambiguity.

---
*PR created automatically by Jules for task [7242628472724821183](https://jules.google.com/task/7242628472724821183) started by @EiJackGH*