### PR TITLE
🎨 Palette: Add explicit empty state for highscore

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-08-07 - Add explicit empty states
+**Learning:** In CLI applications, explicitly stating when data is empty (like an un-set highscore) improves clarity over hiding the field completely, helping onboard users better.
+**Action:** Always provide explicit, encouraging empty states instead of completely hiding the UI element.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_NORM << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What**: Added an explicit empty state when `highscore` is 0, showing "None yet! Play to set a record!" instead of hiding the highscore completely.

🎯 **Why**: In CLI applications, explicitly stating when data is empty helps clarify the system state to new users and provides a better onboarding experience, compared to just hiding the UI element.

📸 **Before/After**:
*Before:*
(Nothing shown if highscore is 0)

*After:*
Personal Best: None yet! Play to set a record!

♿ **Accessibility**: Improves cognitive accessibility by clearly indicating the state of the user's progress rather than relying on absence of information.

---
*PR created automatically by Jules for task [6646254920997600061](https://jules.google.com/task/6646254920997600061) started by @EiJackGH*