### PR TITLE
🎨 Palette: Add explicit empty state for high score

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-06-20 - Explicit Empty States in CLI
+**Learning:** Hiding UI elements (like a high score) when they are empty leaves new users without context of what they can achieve.
+**Action:** Provide explicit, encouraging empty states (e.g. "None yet! Go set a record!") to clarify the system state and improve user onboarding.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Go set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 **What:** Added an explicit empty state message ("None yet! Go set a record!") when the high score is 0.
🎯 **Why:** Hiding the high score when it's empty leaves new users without context. Displaying an encouraging message improves user onboarding and clarifies the system state.
📸 **Before/After:** Before, nothing was displayed if the highscore was 0. After, it shows "Personal Best: None yet! Go set a record!".
♿ **Accessibility:** Improves cognitive accessibility by providing clear context and removing ambiguity for new players.

---
*PR created automatically by Jules for task [16750595286569341438](https://jules.google.com/task/16750595286569341438) started by @EiJackGH*