### PR TITLE
🎨 Palette: Add detailed game-over session summary statistics

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <csignal>
 #include <cstdlib>
+#include <iomanip>
 #include "utils.hpp"
 
 // Color and formatting macros for terminal output
@@ -73,6 +74,7 @@ int main() {
     long long highscore = load_highscore();
     long long initialHighscore = highscore;
     long long score = 0;
+    long long manual_clicks = 0;
     bool hardMode = false;
     char input;
 
@@ -115,6 +117,7 @@ int main() {
     tcflush(STDIN_FILENO, TCIFLUSH);
 
     auto last_tick = std::chrono::steady_clock::now();
+    auto game_start = std::chrono::steady_clock::now();
     bool updateUI = true;
     struct pollfd fds[1] = {{STDIN_FILENO, POLLIN, 0}};
     while (true) {
@@ -128,6 +131,7 @@ int main() {
             if (input == 'h') hardMode = !hardMode;
             else {
                 score++;
+                manual_clicks++;
                 if (score > highscore) highscore = score;
             }
             updateUI = true;
@@ -151,6 +155,13 @@ int main() {
         }
     }
 
+    auto game_end = std::chrono::steady_clock::now();
+    double duration_sec = std::chrono::duration_cast<std::chrono::milliseconds>(game_end - game_start).count() / 1000.0;
+    double cps = 0.0;
+    if (duration_sec > 0.0) {
+        cps = manual_clicks / duration_sec;
+    }
+
     if (score > initialHighscore) {
         save_highscore(score);
     }
@@ -160,6 +171,12 @@ int main() {
     if (score > initialHighscore) {
         std::cout << "Congratulations! A new personal best!\n";
     }
+
+    std::cout << "\n" << CLR_CTRL << "=== SESSION SUMMARY ===" << CLR_RESET << "\n";
+    std::cout << " Manual Clicks: " << CLR_SCORE << formatWithCommas(manual_clicks) << CLR_RESET << "\n";
+    std::cout << " Game Duration: " << CLR_SCORE << std::fixed << std::setprecision(1) << duration_sec << "s" << CLR_RESET << "\n";
+    std::cout << " Average Speed: " << CLR_SCORE << std::fixed << std::setprecision(2) << cps << " CPS" << CLR_RESET << "\n\n";
+
     std::cout << "Thanks for playing!\n";
     std::cout << "\033[?25h" << std::flush;
     return 0;


### PR DESCRIPTION
Added a detailed game-over session summary that displays manual clicks (formatted with commas), game session duration in seconds (formatted to 1 decimal place), and average clicks-per-second (CPS) speed (formatted to 2 decimal places). This provides immediate, rewarding feedback to the player upon completing a run.

---
*PR created automatically by Jules for task [15016362476105335087](https://jules.google.com/task/15016362476105335087) started by @aidasofialily-cmd*