### PR TITLE
🎨 Palette: Add explicit empty state for highscore display

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2024-04-24 - Avoiding Trailing Artifacts in CLI Applications
 **Learning:** When dynamically updating terminal lines using carriage return (`\r`), relying on hardcoded padding spaces to overwrite old text is brittle and leads to trailing text artifacts when new lines are shorter than previous ones.
 **Action:** Always use the ANSI escape sequence `\033[K` (Erase in Line) immediately after the carriage return (`\r`) to cleanly clear the line before writing new content, rather than manually managing padding spaces.
+
+## 2024-05-24 - Add Empty State for High Scores
+**Learning:** Explicit, encouraging empty states for data or achievements in CLI applications improve user onboarding more effectively than simply hiding the UI element when empty.
+**Action:** Always provide a clear, friendly fallback state (e.g. "None yet. Play to set a record!") for zero/null values in player statistics or metrics instead of omitting them.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,8 @@ int main() {
 
     if (highscore > 0) {
         std::cout << " Personal Best: " << CLR_SCORE << formatWithCommas(highscore) << CLR_RESET << "\n\n";
+    } else {
+        std::cout << " Personal Best: " << CLR_SCORE << "None yet! Play to set a record!" << CLR_RESET << "\n\n";
     }
 
     std::cout << "Controls:\n " << CLR_CTRL << "[h]" << CLR_RESET << " Toggle Hard Mode (10x Speed!)\n "


### PR DESCRIPTION
💡 What: Added an explicit, encouraging message when the high score is 0 ("None yet! Play to set a record!") instead of hiding the high score display.
🎯 Why: Improves onboarding for new users by clarifying the system state and providing a clear goal, rather than having a missing UI element.
📸 Before/After: N/A (CLI text change).
♿ Accessibility: Improves cognitive accessibility by explicitly declaring state rather than relying on absence of information.

---
*PR created automatically by Jules for task [6083370579541755543](https://jules.google.com/task/6083370579541755543) started by @EiJackGH*